### PR TITLE
drop two flags for ubuntu builds

### DIFF
--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -11,9 +11,7 @@ DESTDIR="$DESTINATION" make install prefix=/ \
     NO_PERL=1 \
     NO_TCLTK=1 \
     NO_GETTEXT=1 \
-    USE_LIBPCRE=1 \
     NO_OPENSSL=1 \
-    NO_CROSS_DIRECTORY_HARDLINKS=1 \
     NO_INSTALL_HARDLINKS=1 \
     CC='gcc' \
     CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2' \


### PR DESCRIPTION
From the makefile:

```make
# Define USE_LIBPCRE if you have and want to use libpcre. git-grep will be
# able to use Perl-compatible regular expressions.
```

We're not shipping Perl, so we shouldn't need to support this for our usage.

```make
# Define NO_CROSS_DIRECTORY_HARDLINKS if you plan to distribute the installed
# programs as a tar, where bin/ and libexec/ might be on different file systems.
```

These won't ever be on different filesystems.