### PR TITLE
actually gzip everything

### DIFF
--- a/script/package.sh
+++ b/script/package.sh
@@ -31,7 +31,7 @@ else
   exit 1
 fi
 
-tar -cvjzf $FILE -C $DESTINATION .
+tar -cvzf $FILE -C $DESTINATION .
 CHECKSUM=$(shasum -a 256 $FILE | awk '{print $1;}')
 
 tar -tzf $FILE


### PR DESCRIPTION
I'm pretty sure that I didn't enable gzip compression on these packages, as when testing the unpacking in node I'd consistently get this error:

```
Error: incorrect header check
    at Zlib._handle.onerror (zlib.js:370:17)
```

I've dropped the fancy `.tgz` format for the classic `.tar.gz`, and checking I can read the archive after it's been created.