### PR TITLE
Avoid glibc 2.16 dependency

### DIFF
--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -14,7 +14,7 @@ DESTDIR="$DESTINATION" make install prefix=/ \
     NO_OPENSSL=1 \
     NO_INSTALL_HARDLINKS=1 \
     CC='gcc' \
-    CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2' \
+    CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
     LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro'
 cd -
 
@@ -37,5 +37,3 @@ cd $DESTINATION
 mkdir ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
 cd -
-
-


### PR DESCRIPTION
Building git with `-U_FORTIFY_SOURCE` instead of `-D_FORTIFY_SOURCE=2` removes the dependency from the `git-upload-pack` binary on glibc 2.16 by way of the `__poll_chk` function as a possible fix for desktop/git-native-bits#13.

I don't actually know what I'm doing here, so I'm not sure if this is the right way to go about doing this or what the other ramifications of disabling `FORTIFY_SOURCE` may be. From what I've seen in the man page, it looks like it adds buffer overflow sanity checks to glibc functions, which sounds like a bad thing to turn off... but the `__pol_chk` call is guarded by an `#ifdef _FORTIFY_SOURCE` block. There's a [StackOverflow question](http://stackoverflow.com/questions/35362844/version-glibc-2-16-not-found-target-host-error-after-upgrading-build-environ#) with an almost identical problem that led me to this possible solution.

I also stumbled across [a blog post on creating portable Linux binaries,](http://insanecoding.blogspot.com/2012/07/creating-portable-linux-binaries.html) although I wasn't fond of the suggestion in there to manually edit headers on the build machine (even if we could do that here with some `sed` magic in the build scripts).

#### Built with `-D_FORTIFY_SOURCE=2`

```bash
smash @ winter ~/code/git-native-bits (aw-older-glibc *%=) 
$ ldd -v /tmp/build/git/bin/git-upload-pack 
# ...
	Version information:
	/tmp/build/git/bin/git-upload-pack:
                # ...
		libc.so.6 (GLIBC_2.16) => /lib/x86_64-linux-gnu/libc.so.6
                # ...
smash @ winter ~/code/git-native-bits (aw-older-glibc *%=) 
$ objdump -T /tmp/build/git/bin/git-upload-pack | grep GLIBC_2.16
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.16  __poll_chk
```

#### Built with `-U_FORTIFY_SOURCE`

```bash
$ ldd -v /tmp/build/git/bin/git-upload-pack 
# ...
	Version information:
	/tmp/build/git/bin/git-upload-pack:
		librt.so.1 (GLIBC_2.2.5) => /lib/x86_64-linux-gnu/librt.so.1
		libz.so.1 (ZLIB_1.2.0) => /lib/x86_64-linux-gnu/libz.so.1
		libpthread.so.0 (GLIBC_2.2.5) => /lib/x86_64-linux-gnu/libpthread.so.0
		libc.so.6 (GLIBC_2.3) => /lib/x86_64-linux-gnu/libc.so.6
		libc.so.6 (GLIBC_2.3.4) => /lib/x86_64-linux-gnu/libc.so.6
		libc.so.6 (GLIBC_2.14) => /lib/x86_64-linux-gnu/libc.so.6
		libc.so.6 (GLIBC_2.4) => /lib/x86_64-linux-gnu/libc.so.6
		libc.so.6 (GLIBC_2.2.5) => /lib/x86_64-linux-gnu/libc.so.6
# ...
smash @ winter ~/code/git-native-bits (aw-older-glibc %=) 
$ objdump -T /tmp/build/git/bin/git-upload-pack | grep GLIBC_2.16
smash @ winter ~/code/git-native-bits (aw-older-glibc %=) [1] 
$ objdump -T /tmp/build/git/bin/git-upload-pack | grep GLIBC_2.14
0000000000000000      DF *UND*	0000000000000000  GLIBC_2.14  memcpy
```

From that output, this takes us back to glibc 2.14, which is a [June 2011 release](https://en.wikipedia.org/wiki/GNU_C_Library#Version_history) supported in Debian 8, Ubuntu 12.04, and RHEL 7.

If we can nix that memcpy symbol too we might be able to drop our glibc version requirement to 2.4 to take us all the way back to a March 2006 to include Debian 5, Ubuntu 8.04, and RHEL 5.

Oh, also, I admit I don't fully understand the hack linked in desktop/git-native-bits#13. From what I can tell, that's overriding the `GLIBC` version constants that tag symbols in the ELF binary... but wouldn't that :boom: in a really bad way if you are running against an older glibc? Essentially that would be fudging our binaries to lie to the dynamic linker and hoping that nobody notices :thinking: 