### PR TITLE
swap in curl-winssl for curl-openssl on Windows

### DIFF
--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -49,4 +49,30 @@ WINSSL_CURL_LIBRARY="$DESTINATION/mingw64/bin/curl-winssl/libcurl-4.dll"
 mv $WINSSL_CURL_LIBRARY $ORIGINAL_CURL_LIBRARY
 rm -rf "$DESTINATION/mingw64/bin/curl-winssl/"
 
-# TODO: validate change
+if [ "$APPVEYOR" == "True" ]; then
+  # find the version of libcurl that was bundled
+  PACKAGE_ENTRY=$(grep -o 'curl [0-9].[0-9]\{2\}.[0-9]-[0-9]' /tmp/build/git/etc/package-versions.txt)
+  PACKAGE_VERSION=${PACKAGE_ENTRY/curl /}
+
+  echo "Using curl version version $PACKAGE_VERSION"
+  CURL_FILE="curl.tar.xz"
+  CURL_BINARY_DOWNLOAD="https://dl.bintray.com/git-for-windows/pacman/x86_64/mingw-w64-x86_64-curl-$PACKAGE_VERSION-any.pkg.tar.xz"
+  curl -sL -o $CURL_FILE $CURL_BINARY_DOWNLOAD
+
+  # extract just the executable to test alongside our libcurl-4.dll change
+  7z e $CURL_FILE -aoa -ooutput > nul
+  7z e output/curl.tar -aoa -ooutput *.exe -r > nul
+  cp ./output/curl.exe "$DESTINATION/mingw64/bin/"
+  rm -rf ./output
+
+  $DESTINATION/mingw64/bin/curl.exe --version | grep 'WinSSL'
+  EXIT_CODE=$?
+  rm $DESTINATION/mingw64/bin/curl.exe
+
+  if [ "$EXIT_CODE" == "1" ]; then
+    echo "cURL not able to resolve WinSSL dependency. Failing the build..."
+    exit 1
+  else
+    echo "Verified cURL dependency is using WinSSL"
+  fi
+fi

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -41,3 +41,13 @@ else
   echo "aborting..."
   exit 1
 fi
+
+# replace OpenSSL curl with the WinSSL variant
+# this was recently incorporated into MinGit, so let's just move the file over and cleanup
+ORIGINAL_CURL_LIBRARY="$DESTINATION/mingw64/bin/libcurl-4.dll"
+if [ ! -f $ORIGINAL_CURL_LIBRARY ]; then echo "The source cURL library doesn't exist"; fi
+WINSSL_CURL_LIBRARY="$DESTINATION/mingw64/bin/curl-winssl/libcurl-4.dll"
+if [ ! -f $WINSSL_CURL_LIBRARY ]; then echo "The modified cURL library doesn't exist"; fi
+
+# TODO: move $WINSSL_CURL_LIBRARY to replace $ORIGINAL_CURL_LIBRARY
+# TODO: remove "$DESTINATION/mingw64/bin/curl-winssl/""

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -70,9 +70,9 @@ if [ "$APPVEYOR" == "True" ]; then
   rm $DESTINATION/mingw64/bin/curl.exe
 
   if [ "$EXIT_CODE" == "1" ]; then
-    echo "cURL not able to resolve WinSSL dependency. Failing the build..."
+    echo "curl not able to resolve WinSSL dependency. Failing the build..."
     exit 1
   else
-    echo "Verified cURL dependency is using WinSSL"
+    echo "Verified curl dependency is using WinSSL"
   fi
 fi

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -45,9 +45,8 @@ fi
 # replace OpenSSL curl with the WinSSL variant
 # this was recently incorporated into MinGit, so let's just move the file over and cleanup
 ORIGINAL_CURL_LIBRARY="$DESTINATION/mingw64/bin/libcurl-4.dll"
-if [ ! -f $ORIGINAL_CURL_LIBRARY ]; then echo "The source cURL library doesn't exist"; fi
 WINSSL_CURL_LIBRARY="$DESTINATION/mingw64/bin/curl-winssl/libcurl-4.dll"
-if [ ! -f $WINSSL_CURL_LIBRARY ]; then echo "The modified cURL library doesn't exist"; fi
+mv $WINSSL_CURL_LIBRARY $ORIGINAL_CURL_LIBRARY
+rm -rf "$DESTINATION/mingw64/bin/curl-winssl/"
 
-# TODO: move $WINSSL_CURL_LIBRARY to replace $ORIGINAL_CURL_LIBRARY
-# TODO: remove "$DESTINATION/mingw64/bin/curl-winssl/""
+# TODO: validate change


### PR DESCRIPTION
 - [x] validate files are found at the right spot
 - [x] swap the `winssl` file in for the `openssl` version
 - [x] drop `curl.exe` into distribution to verify WinSSL is detected