### PR TITLE
AppVeyor support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,21 @@ matrix:
     - os: linux
       language: c
       env:
-        - PLATFORM=ubuntu
+        - TARGET_PLATFORM=ubuntu
         - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.0.2/git-lfs-linux-amd64-2.0.2.tar.gz
         - GIT_LFS_CHECKSUM=4b3869aa5445b43146248d5edbf288eebfcce245913d4a0702c35217916a4422
 
     - os: osx
       language: c
       env:
-       - PLATFORM=macOS
+       - TARGET_PLATFORM=macOS
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.0.2/git-lfs-darwin-amd64-2.0.2.tar.gz
        - GIT_LFS_CHECKSUM=0f5feb0105736f2350f286caca51fa9f8ad673d2ff9a4187e649e82374c590a9
 
     - os: linux
       language: c
       env:
-       - PLATFORM=win32
+       - TARGET_PLATFORM=win32
        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/MinGit-2.12.2.2-64-bit.zip
        - GIT_FOR_WINDOWS_CHECKSUM=3918cd9ab42c9a22aa3934463fdb536485c84e6876e9aaab74003deb43a08a36
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.0.2/git-lfs-windows-amd64-2.0.2.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+image: Visual Studio 2015
+
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+environment:
+  TARGET_PLATFORM: win32
+  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/MinGit-2.12.2.2-64-bit.zip
+  GIT_FOR_WINDOWS_CHECKSUM: 3918cd9ab42c9a22aa3934463fdb536485c84e6876e9aaab74003deb43a08a36
+  GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.0.2/git-lfs-windows-amd64-2.0.2.zip
+  GIT_LFS_CHECKSUM: 1b33c8cb6e2e3238b48c639738d22d755a98f7cb62a994d026bb73c158508689
+
+build_script:
+  - cmd: git submodule update --init --recursive
+  - bash script\build.sh
+  - bash script\package.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,3 +14,5 @@ build_script:
   - cmd: git submodule update --init --recursive
   - bash script\build.sh
   - bash script\package.sh
+
+test: off

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -31,15 +31,15 @@ need to do platform-specific things.
 Windows doesn't need to be built from source, however it should be updated in
 step with the other Git releases. When a new [Git for Windows](https://github.com/git-for-windows/git)
 release is made available, just update the `GIT_FOR_WINDOWS_URL` and
-`GIT_FOR_WINDOWS_CHECKSUM` variables in `.travis.yml` to use their MinGit
-build.
+`GIT_FOR_WINDOWS_CHECKSUM` variables in `.travis.yml` and `appveyor.yml` to use
+their MinGit build.
 
 ## Update Git LFS
 
 Packages are published for each platform from the [Git LFS](https://github.com/git-lfs/git-lfs)
-repository. These are defined as environment variables in the `.travis.yml` -
-update the `GIT_LFS_URL` and `GIT_LFS_CHECKSUM` for all platforms and commit
-the change.
+repository. These are defined as environment variables in the `.travis.yml` and
+`appveyor.yml` files - update the `GIT_LFS_URL` and `GIT_LFS_CHECKSUM` for all
+platforms and commit the change.
 
 ## Add a new component
 

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -9,7 +9,12 @@ mkdir -p $DESTINATION
 # download Git for Windows, verify its the right contents, and unpack it
 GIT_FOR_WINDOWS_FILE=git-for-windows.zip
 curl -sL -o $GIT_FOR_WINDOWS_FILE $GIT_FOR_WINDOWS_URL
-COMPUTED_SHA256=$(shasum -a 256 $GIT_FOR_WINDOWS_FILE | awk '{print $1;}')
+if [ "$APPVEYOR" == "True" ]; then
+  COMPUTED_SHA256=$(sha256sum $GIT_FOR_WINDOWS_FILE | awk '{print $1;}')
+else
+  COMPUTED_SHA256=$(shasum -a 256 $GIT_FOR_WINDOWS_FILE | awk '{print $1;}')
+fi
+
 if [ "$COMPUTED_SHA256" = "$GIT_FOR_WINDOWS_CHECKSUM" ]; then
   echo "Git for Windows: checksums match"
   unzip -qq $GIT_FOR_WINDOWS_FILE -d $DESTINATION
@@ -22,7 +27,11 @@ fi
 # download Git LFS, verify its the right contents, and unpack it
 GIT_LFS_FILE=git-lfs.zip
 curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
-COMPUTED_SHA256=$(shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}')
+if [ "$APPVEYOR" == "True" ]; then
+  COMPUTED_SHA256=$(sha256sum $GIT_LFS_FILE | awk '{print $1;}')
+else
+  COMPUTED_SHA256=$(shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}')
+fi
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
   SUBFOLDER="$DESTINATION/mingw64/libexec/git-core/"

--- a/script/build.sh
+++ b/script/build.sh
@@ -9,13 +9,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE="./git"
 DESTINATION="/tmp/build/git"
 
-if [ "$PLATFORM" == "ubuntu" ]; then
+if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
   sh "$DIR/build-ubuntu.sh" $SOURCE $DESTINATION
-elif [ "$PLATFORM" == "macOS" ]; then
+elif [ "$TARGET_PLATFORM" == "macOS" ]; then
   sh "$DIR/build-macos.sh" $SOURCE $DESTINATION
-elif [ "$PLATFORM" == "win32" ]; then
+elif [ "$TARGET_PLATFORM" == "win32" ]; then
   sh "$DIR/build-win32.sh" $DESTINATION
 else
-  echo "Unable to build Git for platform $PLATFORM"
+  echo "Unable to build Git for platform $TARGET_PLATFORM"
   exit 1
 fi

--- a/script/package.sh
+++ b/script/package.sh
@@ -26,19 +26,27 @@ if ! [ -d "$DESTINATION" ]; then
   exit 1
 fi
 
-if [ "$PLATFORM" == "ubuntu" ]; then
+if [ "$APPVEYOR" == "True" ]; then
+  BUILD=$APPVEYOR_BUILD_NUMBER
+fi
+
+if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
   FILE="dugite-native-$VERSION-ubuntu-$BUILD.tar.gz"
-elif [ "$PLATFORM" == "macOS" ]; then
+elif [ "$TARGET_PLATFORM" == "macOS" ]; then
   FILE="dugite-native-$VERSION-macOS-$BUILD.tar.gz"
-elif [ "$PLATFORM" == "win32" ]; then
+elif [ "$TARGET_PLATFORM" == "win32" ]; then
   FILE="dugite-native-$VERSION-win32-$BUILD.tar.gz"
 else
-  echo "Unable to package Git for platform $PLATFORM"
+  echo "Unable to package Git for platform $TARGET_PLATFORM"
   exit 1
 fi
 
 tar -cvzf $FILE -C $DESTINATION .
-CHECKSUM=$(shasum -a 256 $FILE | awk '{print $1;}')
+if [ "$APPVEYOR" == "True" ]; then
+  CHECKSUM=$(sha256sum $FILE | awk '{print $1;}')
+else
+  CHECKSUM=$(shasum -a 256 $FILE | awk '{print $1;}')
+fi
 
 tar -tzf $FILE
 


### PR DESCRIPTION
This adds the same building and packaging steps to AppVeyor, so we can test Windows-specific things easily.

I'd rather leave Travis to be the canonical source for packaging, but I think I can emulate the "package and publish from tag" behaviour from AppVeyor if we need to start building from source.