### PR TITLE
some tracing and cleanup

### DIFF
--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -6,7 +6,22 @@
 SOURCE=$1
 DESTINATION=$2
 
-echo "Building git at $SOURCE to $DESTINATION"
+# i want to centralize this function but everything is terrible
+# go read https://github.com/desktop/dugite-native/issues/38
+computeChecksum() {
+   if [ -z "$1" ] ; then
+     # no parameter provided, fail hard
+     exit 1
+   fi
+
+  path_to_sha256sum=$(which sha256sum)
+  if [ -x "$path_to_sha256sum" ] ; then
+    echo $(sha256sum $1 | awk '{print $1;}')
+  else
+    echo $(shasum -a 256 $1 | awk '{print $1;}')
+  fi
+}
+
 
 cd $SOURCE
 make clean
@@ -22,7 +37,7 @@ cd - > /dev/null
 # download Git LFS, verify its the right contents, and unpack it
 GIT_LFS_FILE=git-lfs.tar.gz
 curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
-COMPUTED_SHA256=$(shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}')
+COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
   SUBFOLDER="$DESTINATION/libexec/git-core"

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -22,6 +22,7 @@ computeChecksum() {
   fi
 }
 
+echo "-- Building git at $SOURCE to $DESTINATION"
 
 cd $SOURCE
 make clean
@@ -34,7 +35,7 @@ DESTDIR="$DESTINATION" make install prefix=/ \
     MACOSX_DEPLOYMENT_TARGET=10.9
 cd - > /dev/null
 
-# download Git LFS, verify its the right contents, and unpack it
+echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.tar.gz
 curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -6,6 +6,22 @@
 SOURCE=$1
 DESTINATION=$2
 
+# i want to centralize this function but everything is terrible
+# go read https://github.com/desktop/dugite-native/issues/38
+computeChecksum() {
+   if [ -z "$1" ] ; then
+     # no parameter provided, fail hard
+     exit 1
+   fi
+
+  path_to_sha256sum=$(which sha256sum)
+  if [ -x "$path_to_sha256sum" ] ; then
+    echo $(sha256sum $1 | awk '{print $1;}')
+  else
+    echo $(shasum -a 256 $1 | awk '{print $1;}')
+  fi
+}
+
 echo "Building git at $SOURCE to $DESTINATION"
 
 cd $SOURCE
@@ -25,7 +41,7 @@ cd - > /dev/null
 GIT_LFS_FILE=git-lfs.tar.gz
 curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
 shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}'
-COMPUTED_SHA256=$(shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}')
+COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
   SUBFOLDER="$DESTINATION/libexec/git-core"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -22,7 +22,7 @@ computeChecksum() {
   fi
 }
 
-echo "Building git at $SOURCE to $DESTINATION"
+echo " -- Building git at $SOURCE to $DESTINATION"
 
 cd $SOURCE
 make clean
@@ -37,7 +37,7 @@ DESTDIR="$DESTINATION" make install prefix=/ \
     LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro'
 cd - > /dev/null
 
-# download Git LFS, verify its the right contents, and unpack it
+echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.tar.gz
 curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
 shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}'
@@ -54,6 +54,7 @@ fi
 
 # download CA bundle and write straight to temp folder
 # for more information: https://curl.haxx.se/docs/caextract.html
+echo "-- Adding CA bundle"
 cd $DESTINATION
 mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -3,18 +3,29 @@
 # Repackaging Git for Windows and bundling Git LFS from upstream.
 #
 
+# i want to centralize this function but everything is terrible
+# go read https://github.com/desktop/dugite-native/issues/38
+computeChecksum() {
+   if [ -z "$1" ] ; then
+     # no parameter provided, fail hard
+     exit 1
+   fi
+
+  path_to_sha256sum=$(which sha256sum)
+  if [ -x "$path_to_sha256sum" ] ; then
+    echo $(sha256sum $1 | awk '{print $1;}')
+  else
+    echo $(shasum -a 256 $1 | awk '{print $1;}')
+  fi
+}
+
 DESTINATION=$1
 mkdir -p $DESTINATION
 
 # download Git for Windows, verify its the right contents, and unpack it
 GIT_FOR_WINDOWS_FILE=git-for-windows.zip
 curl -sL -o $GIT_FOR_WINDOWS_FILE $GIT_FOR_WINDOWS_URL
-if [ "$APPVEYOR" == "True" ]; then
-  COMPUTED_SHA256=$(sha256sum $GIT_FOR_WINDOWS_FILE | awk '{print $1;}')
-else
-  COMPUTED_SHA256=$(shasum -a 256 $GIT_FOR_WINDOWS_FILE | awk '{print $1;}')
-fi
-
+COMPUTED_SHA256=$(computeChecksum $GIT_FOR_WINDOWS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_FOR_WINDOWS_CHECKSUM" ]; then
   echo "Git for Windows: checksums match"
   unzip -qq $GIT_FOR_WINDOWS_FILE -d $DESTINATION
@@ -27,11 +38,7 @@ fi
 # download Git LFS, verify its the right contents, and unpack it
 GIT_LFS_FILE=git-lfs.zip
 curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
-if [ "$APPVEYOR" == "True" ]; then
-  COMPUTED_SHA256=$(sha256sum $GIT_LFS_FILE | awk '{print $1;}')
-else
-  COMPUTED_SHA256=$(shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}')
-fi
+COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
   SUBFOLDER="$DESTINATION/mingw64/libexec/git-core/"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -22,20 +22,21 @@ computeChecksum() {
 DESTINATION=$1
 mkdir -p $DESTINATION
 
-# download Git for Windows, verify its the right contents, and unpack it
+echo "-- Downloading MinGit"
 GIT_FOR_WINDOWS_FILE=git-for-windows.zip
 curl -sL -o $GIT_FOR_WINDOWS_FILE $GIT_FOR_WINDOWS_URL
 COMPUTED_SHA256=$(computeChecksum $GIT_FOR_WINDOWS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_FOR_WINDOWS_CHECKSUM" ]; then
-  echo "Git for Windows: checksums match"
+  echo "MinGit: checksums match"
   unzip -qq $GIT_FOR_WINDOWS_FILE -d $DESTINATION
 else
-  echo "Git for Windows: expected checksum $GIT_FOR_WINDOWS_CHECKSUM but got $COMPUTED_SHA256"
+  echo "MinGit: expected checksum $GIT_FOR_WINDOWS_CHECKSUM but got $COMPUTED_SHA256"
   echo "aborting..."
   exit 1
 fi
 
 # download Git LFS, verify its the right contents, and unpack it
+echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.zip
 curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
@@ -51,6 +52,7 @@ fi
 
 # replace OpenSSL curl with the WinSSL variant
 # this was recently incorporated into MinGit, so let's just move the file over and cleanup
+echo "-- Switching curl to use S-Channel"
 ORIGINAL_CURL_LIBRARY="$DESTINATION/mingw64/bin/libcurl-4.dll"
 WINSSL_CURL_LIBRARY="$DESTINATION/mingw64/bin/curl-winssl/libcurl-4.dll"
 mv $WINSSL_CURL_LIBRARY $ORIGINAL_CURL_LIBRARY

--- a/script/package.sh
+++ b/script/package.sh
@@ -50,5 +50,8 @@ fi
 
 tar -tzf $FILE
 
+SIZE=$(du -h $FILE | cut -f1)
+
 echo "Package created: ${FILE}"
+echo "Size: ${SIZE}"
 echo "SHA256: ${CHECKSUM}"


### PR DESCRIPTION
Some other missing bits from #37 

 - a consistent approach to computing the SHA256 checksum
 - indenting the steps for each build to make them stand out from the rest of the output
 - output the file size (friendly, e.g `21M`) after packaging, so you can see at a glance if it looks authentic