### PR TITLE
bump Git LFS to v2.1.1 to address security vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,15 @@ matrix:
       language: c
       env:
         - TARGET_PLATFORM=ubuntu
-        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.0/git-lfs-linux-amd64-2.1.0.tar.gz
-        - GIT_LFS_CHECKSUM=0260d1908b097dcd703ef6cf83d9c32c1a418325d29b063bf03a165e3dd8e364
+        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.1/git-lfs-linux-amd64-2.1.1.tar.gz
+        - GIT_LFS_CHECKSUM=ee41f7aa2e860ab2abf065bef71e7344b9777c5da25cde8a36891e4d8eb2bbdf
 
     - os: osx
       language: c
       env:
        - TARGET_PLATFORM=macOS
-       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.0/git-lfs-darwin-amd64-2.1.0.tar.gz
-       - GIT_LFS_CHECKSUM=e7c841a4a7d6e5f319c21f7836f6cbad1f1abe93c3dc6f532903c9b8cf589b3c
+       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.1/git-lfs-darwin-amd64-2.1.1.tar.gz
+       - GIT_LFS_CHECKSUM=acefceb077d77d69e35f0017de91b8ea42cf980315226446b5c1dcafd9328e53
 
     - os: linux
       language: c
@@ -20,8 +20,8 @@ matrix:
        - TARGET_PLATFORM=win32
        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.13.0.windows.1/MinGit-2.13.0-64-bit.zip
        - GIT_FOR_WINDOWS_CHECKSUM=20acda973eca1df056ad08bec6e05c3136f40a1b90e2a290260dfc36e9c2c800
-       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.0/git-lfs-windows-amd64-2.1.0.zip
-       - GIT_LFS_CHECKSUM=a40adc489a99d1b7809aab89fa78b6dee2399af6542e4b9faae552a7a248c1ce
+       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.1/git-lfs-windows-amd64-2.1.1.zip
+       - GIT_LFS_CHECKSUM=0866259d6b097f8ff379326f798a93034b61952382011671b80ecf4cc733de57
 
 compiler:
   - gcc


### PR DESCRIPTION
Similar to #43 but applying this to the latest Git release `v2.13.0`