### PR TITLE
add support for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.tar.gz
 /ssl
+
+node_modules
+build

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -21,20 +21,25 @@ sudo yum install expat-devel
 
 ### Testing
 
-You should be able to emulate the behaviour of Travis by setting environment variables. For example, to package for macOS you could run this:
+After making change to the relevant build or package scripts, you can test these out locally by running one of the test scripts:
 
 ```
-GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.0.0/git-lfs-darwin-amd64-2.0.0.tar.gz \
-GIT_LFS_CHECKSUM=fde18661baef286f0a942adf541527282cf8cd87b955690e10b60b621f9b1671 \
-script/build-macos.sh ./git /tmp/build/git/
+$ test/macos.sh
+$ test/ubuntu.sh
+$ test/win32.sh
 ```
 
-**NOTE:** one potential way to tidy this up could be to have helper scripts read out the details of the `.travis.yml` file so you don't have to duplicate the work.
-
-For example, it could distill down to:
+This script will generate the package contents under `build` at the root of the repository and dump out some diagnostics, so you can see the package contents and file sizes.
 
 ```
-./test macOS /tmp/build/git
+...
+ 52K	/Users/shiftkey/src/desktop/dugite-native/test/../build/git/share
+ 37M	/Users/shiftkey/src/desktop/dugite-native/test/../build/git
+
+Package size:  16M
 ```
 
-This would mean the contributor doesn't need to care about changes to how the pipeline works, and can focus on the behaviour of the scripts.
+The two most interesting points to look at would be the uncompressed size of the folder on disk, and the package size (after compression).
+
+These scripts will perform the same setup that is performed on Travis, and have the same constraints (macOS and Ubuntu are built from source, requiring the necessary toolchains for those platforms).
+

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "homepage": "https://github.com/desktop/dugite-native#readme",
   "dependencies": {
-    "node-yaml": "^3.1.0",
-    "yamljs": "^0.2.10"
+    "node-yaml": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dugite-native",
+  "description": "ad-hoc scripts for helping to contribute",
+  "scripts": {
+    "update-test-harness": "node script/update-test-harness.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/desktop/dugite-native.git"
+  },
+  "author": "",
+  "license": "GPLv2",
+  "bugs": {
+    "url": "https://github.com/desktop/dugite-native/issues"
+  },
+  "homepage": "https://github.com/desktop/dugite-native#readme",
+  "dependencies": {
+    "node-yaml": "^3.1.0",
+    "yamljs": "^0.2.10"
+  }
+}

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -1,0 +1,43 @@
+const fs = require('fs')
+const path = require('path')
+
+function writeEnvironmentToFile(os, env) {
+  const otherArgs = env.slice(1)
+  const environmentVariables = otherArgs.map(a => `${a} \\`).join('\n')
+
+  const script = `build-${os}.sh`
+  const fileContents = `#!/bin/bash
+
+DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$DIR/.."
+
+${environmentVariables}
+. "$ROOT/script/${script}" "$ROOT/git" "$ROOT/build/git/"`
+
+  const destination = path.resolve(__dirname, '..', `test/${os}.sh`)
+  fs.writeFileSync(destination, fileContents, { encoding: 'utf-8', mode: '777' })
+}
+
+const YAML = require('node-yaml')
+
+const travisFile = path.resolve(__dirname, '..', '.travis.yml')
+
+const yamlText = fs.readFileSync(travisFile)
+const yaml = YAML.parse(yamlText)
+
+const platforms = yaml['matrix']['include']
+
+for (const platform of platforms) {
+  const env = platform['env']
+  const target = env[0]
+  const keys = target.split('=')
+  const os = keys[1].toLowerCase()
+
+  if (os === 'ubuntu') {
+    writeEnvironmentToFile(os, env)
+  } else if (os === 'macos') {
+    writeEnvironmentToFile(os, env)
+  } else if (os === 'win32') {
+    writeEnvironmentToFile(os, env)
+  }
+}

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -11,9 +11,24 @@ function writeEnvironmentToFile(os, env) {
 
 DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
 ROOT="$DIR/.."
+SOURCE="$ROOT/git"
+DESTINATION="$ROOT/build/git"
 
 ${environmentVariables}
-. "$ROOT/script/${script}" "$ROOT/git" "$ROOT/build/git/"`
+. "$ROOT/script/${script}" $SOURCE $DESTINATION
+
+FILE="dugite-native-$VERSION-${os}-test.tar.gz"
+
+tar -czf $FILE -C $DESTINATION .
+
+echo "Archive contents:"
+cd $DESTINATION
+du -ah $DESTINATION
+cd - > /dev/null
+
+echo ""
+SIZE=$(du -h $FILE | cut -f1)
+echo "Package size: \${SIZE}"`
 
   const destination = path.resolve(__dirname, '..', `test/${os}.sh`)
   fs.writeFileSync(destination, fileContents, { encoding: 'utf-8', mode: '777' })

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const YAML = require('node-yaml')
 
 function writeEnvironmentToFile(os, env) {
   const otherArgs = env.slice(1)
@@ -17,8 +18,6 @@ ${environmentVariables}
   const destination = path.resolve(__dirname, '..', `test/${os}.sh`)
   fs.writeFileSync(destination, fileContents, { encoding: 'utf-8', mode: '777' })
 }
-
-const YAML = require('node-yaml')
 
 const travisFile = path.resolve(__dirname, '..', '.travis.yml')
 

--- a/test/macos.sh
+++ b/test/macos.sh
@@ -2,7 +2,22 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT="$DIR/.."
+SOURCE="$ROOT/git"
+DESTINATION="$ROOT/build/git"
 
 GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.0/git-lfs-darwin-amd64-2.1.0.tar.gz \
 GIT_LFS_CHECKSUM=e7c841a4a7d6e5f319c21f7836f6cbad1f1abe93c3dc6f532903c9b8cf589b3c \
-. "$ROOT/script/build-macos.sh" "$ROOT/git" "$ROOT/build/git/"
+. "$ROOT/script/build-macos.sh" $SOURCE $DESTINATION
+
+FILE="dugite-native-$VERSION-macos-test.tar.gz"
+
+tar -czf $FILE -C $DESTINATION .
+
+echo "Archive contents:"
+cd $DESTINATION
+du -ah $DESTINATION
+cd - > /dev/null
+
+echo ""
+SIZE=$(du -h $FILE | cut -f1)
+echo "Package size: ${SIZE}"

--- a/test/macos.sh
+++ b/test/macos.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$DIR/.."
+
+GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.0/git-lfs-darwin-amd64-2.1.0.tar.gz \
+GIT_LFS_CHECKSUM=e7c841a4a7d6e5f319c21f7836f6cbad1f1abe93c3dc6f532903c9b8cf589b3c \
+. "$ROOT/script/build-macos.sh" "$ROOT/git" "$ROOT/build/git/"

--- a/test/ubuntu.sh
+++ b/test/ubuntu.sh
@@ -2,7 +2,22 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT="$DIR/.."
+SOURCE="$ROOT/git"
+DESTINATION="$ROOT/build/git"
 
 GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.0/git-lfs-linux-amd64-2.1.0.tar.gz \
 GIT_LFS_CHECKSUM=0260d1908b097dcd703ef6cf83d9c32c1a418325d29b063bf03a165e3dd8e364 \
-. "$ROOT/script/build-ubuntu.sh" "$ROOT/git" "$ROOT/build/git/"
+. "$ROOT/script/build-ubuntu.sh" $SOURCE $DESTINATION
+
+FILE="dugite-native-$VERSION-ubuntu-test.tar.gz"
+
+tar -czf $FILE -C $DESTINATION .
+
+echo "Archive contents:"
+cd $DESTINATION
+du -ah $DESTINATION
+cd - > /dev/null
+
+echo ""
+SIZE=$(du -h $FILE | cut -f1)
+echo "Package size: ${SIZE}"

--- a/test/ubuntu.sh
+++ b/test/ubuntu.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$DIR/.."
+
+GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.0/git-lfs-linux-amd64-2.1.0.tar.gz \
+GIT_LFS_CHECKSUM=0260d1908b097dcd703ef6cf83d9c32c1a418325d29b063bf03a165e3dd8e364 \
+. "$ROOT/script/build-ubuntu.sh" "$ROOT/git" "$ROOT/build/git/"

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$DIR/.."
+
+GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.13.0.windows.1/MinGit-2.13.0-64-bit.zip \
+GIT_FOR_WINDOWS_CHECKSUM=20acda973eca1df056ad08bec6e05c3136f40a1b90e2a290260dfc36e9c2c800 \
+GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.0/git-lfs-windows-amd64-2.1.0.zip \
+GIT_LFS_CHECKSUM=a40adc489a99d1b7809aab89fa78b6dee2399af6542e4b9faae552a7a248c1ce \
+. "$ROOT/script/build-win32.sh" "$ROOT/git" "$ROOT/build/git/"

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -2,9 +2,24 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT="$DIR/.."
+SOURCE="$ROOT/git"
+DESTINATION="$ROOT/build/git"
 
 GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.13.0.windows.1/MinGit-2.13.0-64-bit.zip \
 GIT_FOR_WINDOWS_CHECKSUM=20acda973eca1df056ad08bec6e05c3136f40a1b90e2a290260dfc36e9c2c800 \
 GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.1.0/git-lfs-windows-amd64-2.1.0.zip \
 GIT_LFS_CHECKSUM=a40adc489a99d1b7809aab89fa78b6dee2399af6542e4b9faae552a7a248c1ce \
-. "$ROOT/script/build-win32.sh" "$ROOT/git" "$ROOT/build/git/"
+. "$ROOT/script/build-win32.sh" $SOURCE $DESTINATION
+
+FILE="dugite-native-$VERSION-win32-test.tar.gz"
+
+tar -czf $FILE -C $DESTINATION .
+
+echo "Archive contents:"
+cd $DESTINATION
+du -ah $DESTINATION
+cd - > /dev/null
+
+echo ""
+SIZE=$(du -h $FILE | cut -f1)
+echo "Package size: ${SIZE}"


### PR DESCRIPTION
Fixes #26 by auto-generating the test scripts using on the `.travis.yml` contents. This means you can quickly experiment with build and packaging steps locally:

```
$ ./test/ubuntu.sh
```

Yes, it's a node script. **You don't need to have Node or NPM installed to use these scripts - just for updating**. I wanted to keep this all in bash but the various bash parsing scripts I came across weren't able to map the`matrix.includes` values to keys, so I'm stuck with rolling my own solution and it was quicker to do it with JS.

I'll re-run this script and commit updated versions of the scripts with each release.