### PR TITLE
cleanup gitattributes file from global config

### DIFF
--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -85,3 +85,7 @@ if [ "$APPVEYOR" == "True" ]; then
     echo "Verified curl dependency is using WinSSL"
   fi
 fi
+
+# removing global gitattributes file
+rm "$DESTINATION/mingw64/etc/giattributes"
+echo "removing global gitattributes for handling specific file extensions"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -87,5 +87,5 @@ if [ "$APPVEYOR" == "True" ]; then
 fi
 
 # removing global gitattributes file
-rm "$DESTINATION/mingw64/etc/giattributes"
-echo "removing global gitattributes for handling specific file extensions"
+rm "$DESTINATION/mingw64/etc/gitattributes"
+echo "-- Removing global gitattributes which handles certain file extensions"


### PR DESCRIPTION
This removes the global `gitattributes` file that ships in MinGit as:

 - the behaviour is Windows-specific 
 - the `astextplain` script is not bundled in MinGit (it also requires the Perl runtime)
