### PR TITLE
Trim linux build size

### DIFF
--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -59,3 +59,11 @@ cd $DESTINATION
 mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
 cd - > /dev/null
+
+# removing global gitattributes file
+echo "-- Removing server-side programs"
+rm "$DESTINATION/bin/git-cvsserver"
+rm "$DESTINATION/bin/git-receive-pack"
+rm "$DESTINATION/bin/git-upload-archive"
+rm "$DESTINATION/bin/git-upload-pack"
+rm "$DESTINATION/bin/git-shell"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -26,7 +26,7 @@ echo " -- Building git at $SOURCE to $DESTINATION"
 
 cd $SOURCE
 make clean
-DESTDIR="$DESTINATION" make install prefix=/ \
+DESTDIR="$DESTINATION" make strip install prefix=/ \
     NO_PERL=1 \
     NO_TCLTK=1 \
     NO_GETTEXT=1 \


### PR DESCRIPTION
Fixes #47 

This brings the binary size from 50MB compressed (131MB uncompressed) to 13MB compressed (27MB uncompressed) by doing two things:

 - `make strip install` rather than just `make install` (I'll follow up with macOS and see if that improves it's installer much)
 - removing the unnecessary server-side components that ship in the box:
   - [`git-shell`](https://git-scm.com/docs/git-shell) - restricted login for SSH access
   - `git-receive-pack`, `git-receive-archive` and `git-upload-archive` - related commands that you run within `git-shell`
   - [`git-cvsserver`](https://git-scm.com/docs/git-cvsserver) - a CVS server emulator for Git

I figure no-one really wants these tools at this stage, but they're easy to put back in the future if needed.