### PR TITLE
update git to 2.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
       language: c
       env:
        - TARGET_PLATFORM=win32
-       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.13.3.windows.1/MinGit-2.13.3-64-bit.zip
-       - GIT_FOR_WINDOWS_CHECKSUM=97063e2139cac40f3c8f547b85f031765062581101d69ad468188c9de0b1dca3
+       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip
+       - GIT_FOR_WINDOWS_CHECKSUM=65c12e4959b8874187b68ec37e532fe7fc526e10f6f0f29e699fa1d2449e7d92
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.2.1/git-lfs-windows-amd64-2.2.1.zip
        - GIT_LFS_CHECKSUM=35e120c03061c7a3de8348b970da2278a2e0a865d4c67179801266a2d7674d2d
 

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -5,8 +5,8 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.13.3.windows.1/MinGit-2.13.3-64-bit.zip \
-GIT_FOR_WINDOWS_CHECKSUM=97063e2139cac40f3c8f547b85f031765062581101d69ad468188c9de0b1dca3 \
+GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/MinGit-2.14.1-64-bit.zip \
+GIT_FOR_WINDOWS_CHECKSUM=65c12e4959b8874187b68ec37e532fe7fc526e10f6f0f29e699fa1d2449e7d92 \
 GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.2.1/git-lfs-windows-amd64-2.2.1.zip \
 GIT_LFS_CHECKSUM=35e120c03061c7a3de8348b970da2278a2e0a865d4c67179801266a2d7674d2d \
 . "$ROOT/script/build-win32.sh" $SOURCE $DESTINATION


### PR DESCRIPTION
- [Git 2.14.0 release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.14.0.txt)
- [Git for Windows 2.14.0 release notes](https://github.com/git-for-windows/git/releases/tag/v2.14.0.windows.1)
- [Security hotfix around handling SSH URLs](http://marc.info/?l=git&m=150238802328673&w=2)