### PR TITLE
Update to Git 2.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
       language: c
       env:
        - TARGET_PLATFORM=win32
-       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.14.3.windows.1/MinGit-2.14.3-64-bit.zip
-       - GIT_FOR_WINDOWS_CHECKSUM=538294d2b1472e561493b67855f92380d8139011c74be6bf3cdc5b5d321b1345
+       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.15.0.windows.1/MinGit-2.15.0-64-bit.zip
+       - GIT_FOR_WINDOWS_CHECKSUM=fb5aad5e18a9f9f86e33a94e6fc0f0d88d0defd227e43f10316d871f2123c0d4
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip
        - GIT_LFS_CHECKSUM=18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5
 

--- a/test/macos.sh
+++ b/test/macos.sh
@@ -5,8 +5,8 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.1/git-lfs-darwin-amd64-2.3.1.tar.gz \
-GIT_LFS_CHECKSUM=5b4f81f4afc1447776dcfeaf5ff63fb0b5ea522ccac587aa97942203ac977e0f \
+GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-darwin-amd64-2.3.4.tar.gz \
+GIT_LFS_CHECKSUM=b16d4b7469b1fa34e0e27bedb1b77cc425b8d7903264854e5f18b0bc73576edb \
 . "$ROOT/script/build-macos.sh" $SOURCE $DESTINATION
 
 FILE="dugite-native-$VERSION-macos-test.tar.gz"

--- a/test/ubuntu.sh
+++ b/test/ubuntu.sh
@@ -5,8 +5,8 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.1/git-lfs-linux-amd64-2.3.1.tar.gz \
-GIT_LFS_CHECKSUM=6ea96cf57fba70c425c470c248d0f770f86d3f3ccf5bc3ef6c46fb47c80816a1 \
+GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-linux-amd64-2.3.4.tar.gz \
+GIT_LFS_CHECKSUM=6755e109a85ffd9a03aacc629ea4ab1cbb8e7d83e41bd1880bf44b41927f4cfe \
 . "$ROOT/script/build-ubuntu.sh" $SOURCE $DESTINATION
 
 FILE="dugite-native-$VERSION-ubuntu-test.tar.gz"

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -5,10 +5,10 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.14.2.windows.1/MinGit-2.14.2-64-bit.zip \
-GIT_FOR_WINDOWS_CHECKSUM=9638733b8d749c43d59c34a714d582b2352356ee7d13c4acf919c18f307387f5 \
-GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.1/git-lfs-windows-amd64-2.3.1.zip \
-GIT_LFS_CHECKSUM=61fa2e8122b374b1d7a87f59ed8d3a0d08b4c8ab6cb2d50b4bc61283d91bbf50 \
+GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.15.0.windows.1/MinGit-2.15.0-64-bit.zip \
+GIT_FOR_WINDOWS_CHECKSUM=fb5aad5e18a9f9f86e33a94e6fc0f0d88d0defd227e43f10316d871f2123c0d4 \
+GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip \
+GIT_LFS_CHECKSUM=18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5 \
 . "$ROOT/script/build-win32.sh" $SOURCE $DESTINATION
 
 FILE="dugite-native-$VERSION-win32-test.tar.gz"


### PR DESCRIPTION
Hot off the presses:

 - [Git release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.15.0.txt)
 - [Git for Windows release notes](https://github.com/git-for-windows/git/releases/tag/v2.15.0.windows.1)