### PR TITLE
travis should create the draft release first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,7 @@ deploy:
   file_glob: true
   file: ${TRAVIS_BUILD_DIR}/dugite-native-v*.tar.gz
   skip_cleanup: true
+  draft: true
+  tag_name: $TRAVIS_TAG
   on:
     tags: true


### PR DESCRIPTION
Currently when a tag is pushed to GitHub, Travis kicks off a build and then publishes the artifacts it has without release notes:

<img width="409" alt="screen shot 2017-11-30 at 11 05 04 am" src="https://user-images.githubusercontent.com/359239/33405904-5b276eb4-d5be-11e7-95b3-8a454107f011.png">

This is confusing, and totally unhelpful for downstream consumers.

I _think_ this is how to create the release as a draft first, which a human can then come in and craft the release notes and then :shipit:, based on https://github.com/travis-ci/travis-ci/issues/6132 and https://github.com/bkimminich/juice-shop/commit/727289324b3065bf7825bbb6f4d91b90a6351c32.
