### PR TITLE
use LZMA archives which compress far better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 build
 
 *.zip
+*.lzma

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,9 @@ deploy:
   provider: releases
   api_key: $GITHUB_TOKEN
   file_glob: true
-  file: ${TRAVIS_BUILD_DIR}/dugite-native-v*.tar.gz
+  file:
+    - ${TRAVIS_BUILD_DIR}/dugite-native-v*.tar.gz
+    - ${TRAVIS_BUILD_DIR}/dugite-native-v*.lzma
   skip_cleanup: true
   draft: true
   tag_name: $TRAVIS_TAG

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -17,18 +17,38 @@ DESTINATION="$ROOT/build/git"
 ${environmentVariables}
 . "$ROOT/script/${script}" $SOURCE $DESTINATION
 
-FILE="dugite-native-$VERSION-${os}-test.tar.gz"
-
-tar -czf $FILE -C $DESTINATION .
-
 echo "Archive contents:"
 cd $DESTINATION
 du -ah $DESTINATION
 cd - > /dev/null
 
+GZIP_FILE="dugite-native-$VERSION-${os}-test.tar.gz"
+LZMA_FILE="dugite-native-$VERSION-${os}-test.lzma"
+
 echo ""
-SIZE=$(du -h $FILE | cut -f1)
-echo "Package size: \${SIZE}"`
+echo "Creating archives..."
+if [ "$(uname -s)" == "Darwin" ]; then
+  tar -czf $GZIP_FILE -C $DESTINATION .
+  tar --lzma -cf $LZMA_FILE -C $DESTINATION .
+else
+  tar -caf $GZIP_FILE -C $DESTINATION .
+  tar -caf $LZMA_FILE -C $DESTINATION .
+fi
+
+if [ "$APPVEYOR" == "True" ]; then
+  GZIP_CHECKSUM=$(sha256sum $GZIP_FILE | awk '{print $1;}')
+  LZMA_CHECKSUM=$(sha256sum $LZMA_FILE | awk '{print $1;}')
+else
+  GZIP_CHECKSUM=$(shasum -a 256 $GZIP_FILE | awk '{print $1;}')
+  LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
+fi
+
+GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
+LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+
+echo "Packages created:"
+echo "\${GZIP_FILE} - \${GZIP_SIZE} - checksum: \${GZIP_CHECKSUM}"
+echo "\${LZMA_FILE} - \${LZMA_SIZE} - checksum: \${LZMA_CHECKSUM}"`
 
   const destination = path.resolve(__dirname, '..', `test/${os}.sh`)
   fs.writeFileSync(destination, fileContents, { encoding: 'utf-8', mode: '777' })

--- a/test/macos.sh
+++ b/test/macos.sh
@@ -9,15 +9,35 @@ GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-
 GIT_LFS_CHECKSUM=b16d4b7469b1fa34e0e27bedb1b77cc425b8d7903264854e5f18b0bc73576edb \
 . "$ROOT/script/build-macos.sh" $SOURCE $DESTINATION
 
-FILE="dugite-native-$VERSION-macos-test.tar.gz"
-
-tar -czf $FILE -C $DESTINATION .
-
 echo "Archive contents:"
 cd $DESTINATION
 du -ah $DESTINATION
 cd - > /dev/null
 
+GZIP_FILE="dugite-native-$VERSION-macos-test.tar.gz"
+LZMA_FILE="dugite-native-$VERSION-macos-test.lzma"
+
 echo ""
-SIZE=$(du -h $FILE | cut -f1)
-echo "Package size: ${SIZE}"
+echo "Creating archives..."
+if [ "$(uname -s)" == "Darwin" ]; then
+  tar -czf $GZIP_FILE -C $DESTINATION .
+  tar --lzma -cf $LZMA_FILE -C $DESTINATION .
+else
+  tar -caf $GZIP_FILE -C $DESTINATION .
+  tar -caf $LZMA_FILE -C $DESTINATION .
+fi
+
+if [ "$APPVEYOR" == "True" ]; then
+  GZIP_CHECKSUM=$(sha256sum $GZIP_FILE | awk '{print $1;}')
+  LZMA_CHECKSUM=$(sha256sum $LZMA_FILE | awk '{print $1;}')
+else
+  GZIP_CHECKSUM=$(shasum -a 256 $GZIP_FILE | awk '{print $1;}')
+  LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
+fi
+
+GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
+LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+
+echo "Packages created:"
+echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"
+echo "${LZMA_FILE} - ${LZMA_SIZE} - checksum: ${LZMA_CHECKSUM}"

--- a/test/ubuntu.sh
+++ b/test/ubuntu.sh
@@ -9,15 +9,35 @@ GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-
 GIT_LFS_CHECKSUM=6755e109a85ffd9a03aacc629ea4ab1cbb8e7d83e41bd1880bf44b41927f4cfe \
 . "$ROOT/script/build-ubuntu.sh" $SOURCE $DESTINATION
 
-FILE="dugite-native-$VERSION-ubuntu-test.tar.gz"
-
-tar -czf $FILE -C $DESTINATION .
-
 echo "Archive contents:"
 cd $DESTINATION
 du -ah $DESTINATION
 cd - > /dev/null
 
+GZIP_FILE="dugite-native-$VERSION-ubuntu-test.tar.gz"
+LZMA_FILE="dugite-native-$VERSION-ubuntu-test.lzma"
+
 echo ""
-SIZE=$(du -h $FILE | cut -f1)
-echo "Package size: ${SIZE}"
+echo "Creating archives..."
+if [ "$(uname -s)" == "Darwin" ]; then
+  tar -czf $GZIP_FILE -C $DESTINATION .
+  tar --lzma -cf $LZMA_FILE -C $DESTINATION .
+else
+  tar -caf $GZIP_FILE -C $DESTINATION .
+  tar -caf $LZMA_FILE -C $DESTINATION .
+fi
+
+if [ "$APPVEYOR" == "True" ]; then
+  GZIP_CHECKSUM=$(sha256sum $GZIP_FILE | awk '{print $1;}')
+  LZMA_CHECKSUM=$(sha256sum $LZMA_FILE | awk '{print $1;}')
+else
+  GZIP_CHECKSUM=$(shasum -a 256 $GZIP_FILE | awk '{print $1;}')
+  LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
+fi
+
+GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
+LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+
+echo "Packages created:"
+echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"
+echo "${LZMA_FILE} - ${LZMA_SIZE} - checksum: ${LZMA_CHECKSUM}"

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -11,15 +11,35 @@ GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-
 GIT_LFS_CHECKSUM=18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5 \
 . "$ROOT/script/build-win32.sh" $SOURCE $DESTINATION
 
-FILE="dugite-native-$VERSION-win32-test.tar.gz"
-
-tar -czf $FILE -C $DESTINATION .
-
 echo "Archive contents:"
 cd $DESTINATION
 du -ah $DESTINATION
 cd - > /dev/null
 
+GZIP_FILE="dugite-native-$VERSION-win32-test.tar.gz"
+LZMA_FILE="dugite-native-$VERSION-win32-test.lzma"
+
 echo ""
-SIZE=$(du -h $FILE | cut -f1)
-echo "Package size: ${SIZE}"
+echo "Creating archives..."
+if [ "$(uname -s)" == "Darwin" ]; then
+  tar -czf $GZIP_FILE -C $DESTINATION .
+  tar --lzma -cf $LZMA_FILE -C $DESTINATION .
+else
+  tar -caf $GZIP_FILE -C $DESTINATION .
+  tar -caf $LZMA_FILE -C $DESTINATION .
+fi
+
+if [ "$APPVEYOR" == "True" ]; then
+  GZIP_CHECKSUM=$(sha256sum $GZIP_FILE | awk '{print $1;}')
+  LZMA_CHECKSUM=$(sha256sum $LZMA_FILE | awk '{print $1;}')
+else
+  GZIP_CHECKSUM=$(shasum -a 256 $GZIP_FILE | awk '{print $1;}')
+  LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
+fi
+
+GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
+LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+
+echo "Packages created:"
+echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"
+echo "${LZMA_FILE} - ${LZMA_SIZE} - checksum: ${LZMA_CHECKSUM}"


### PR DESCRIPTION
GZIP is relatively ubiquitous in terms of support, but LZMA actually compresses far better in my testing.

```shellsession
Creating archives...
Packages created:
dugite-native--ubuntu-test.tar.gz - 13M - checksum: 14f2f3d572aedd5b4a498b9582ed19ef26a3d3fbeb52251c763a3b08ba865cf7
dugite-native--ubuntu-test.lzma - 5.2M - checksum: 248f581e2eb2460149adb900b59ca82832a5de62597cf2e56173e732d4ce0dfb
```

So I'll start supporting both formats, for a bit of convenience for consumers.

 - [x] macOS `tar` is different, because of course it is :hurtrealbad: 