### PR TITLE
[WIP] set system configuration values as part of build script

### DIFF
--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -50,6 +50,13 @@ else
   exit 1
 fi
 
+mkdir "$DESTINATION/etc"
+SYSTEM_CONFIG="$DESTINATION/etc/gitconfig"
+touch $SYSTEM_CONFIG
+
+echo "-- Setting status.showUntrackedFiles=all to ensure all untracked files shown by default"
+git config --file $SYSTEM_CONFIG status.showUntrackedFiles all
+
 echo "-- Removing server-side programs"
 rm "$DESTINATION/bin/git-cvsserver"
 rm "$DESTINATION/bin/git-receive-pack"

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -50,12 +50,16 @@ else
   exit 1
 fi
 
-mkdir "$DESTINATION/etc"
+mkdir -p "$DESTINATION/etc"
 SYSTEM_CONFIG="$DESTINATION/etc/gitconfig"
 touch $SYSTEM_CONFIG
 
 echo "-- Setting status.showUntrackedFiles=all to ensure all untracked files shown by default"
 git config --file $SYSTEM_CONFIG status.showUntrackedFiles all
+
+cd "$DESTINATION"
+PREFIX=$DESTINATION ./bin/git config --system -l --show-origin
+cd - > /dev/null
 
 echo "-- Removing server-side programs"
 rm "$DESTINATION/bin/git-cvsserver"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -60,6 +60,12 @@ mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
 cd - > /dev/null
 
+mkdir "$DESTINATION/etc"
+SYSTEM_CONFIG="$DESTINATION/etc/gitconfig"
+touch $SYSTEM_CONFIG
+
+echo "-- Setting status.showUntrackedFiles=all to ensure all untracked files shown by default"
+git config --file $SYSTEM_CONFIG status.showUntrackedFiles all
 
 echo "-- Removing server-side programs"
 rm "$DESTINATION/bin/git-cvsserver"
@@ -72,7 +78,6 @@ echo "-- Removing unsupported features"
 rm "$DESTINATION/libexec/git-core/git-svn"
 rm "$DESTINATION/libexec/git-core/git-remote-testsvn"
 rm "$DESTINATION/libexec/git-core/git-p4"
-
 
 checkStaticLinking() {
   if [ -z "$1" ] ; then

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -60,12 +60,16 @@ mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
 cd - > /dev/null
 
-mkdir "$DESTINATION/etc"
+mkdir -p "$DESTINATION/etc"
 SYSTEM_CONFIG="$DESTINATION/etc/gitconfig"
 touch $SYSTEM_CONFIG
 
 echo "-- Setting status.showUntrackedFiles=all to ensure all untracked files shown by default"
 git config --file $SYSTEM_CONFIG status.showUntrackedFiles all
+
+cd "$DESTINATION"
+PREFIX=$DESTINATION ./bin/git config --system -l --show-origin
+cd - > /dev/null
 
 echo "-- Removing server-side programs"
 rm "$DESTINATION/bin/git-cvsserver"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -58,6 +58,13 @@ git config --file $SYSTEM_CONFIG http.sslBackend schannel
 echo "-- Setting status.showUntrackedFiles=all to ensure all untracked files shown by default"
 git config --file $SYSTEM_CONFIG status.showUntrackedFiles all
 
+
+if [ "$APPVEYOR" == "True" ]; then
+  cd "$DESTINATION"
+  ./cmd/git config --system -l --show-origin
+  cd - > /dev/null
+fi
+
 # removing global gitattributes file
 rm "$DESTINATION/mingw64/etc/gitattributes"
 echo "-- Removing global gitattributes which handles certain file extensions"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -52,8 +52,11 @@ fi
 
 SYSTEM_CONFIG="$DESTINATION/mingw64/etc/gitconfig"
 
-git config --file $SYSTEM_CONFIG http.sslBackend "schannel"
 echo "-- Setting the system configuration to use SChannel for the SSL backend"
+git config --file $SYSTEM_CONFIG http.sslBackend schannel
+
+echo "-- Setting status.showUntrackedFiles=all to ensure all untracked files shown by default"
+git config --file $SYSTEM_CONFIG status.showUntrackedFiles all
 
 # removing global gitattributes file
 rm "$DESTINATION/mingw64/etc/gitattributes"


### PR DESCRIPTION
Investigating a fix for #72:

- [x] ship system configuration at `$(prefix)/etc/gitconfig` for macOS and Linux targets
- [x] confirm custom system config is respected on Windows
- [ ] confirm custom system config is respected on macOS
- [ ] confirm custom system config is respected on Linux

  