### PR TITLE
Add arm64 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+sudo: required
+
+services:
+  - docker
+
 matrix:
   include:
     - os: linux
@@ -22,6 +27,12 @@ matrix:
        - GIT_FOR_WINDOWS_CHECKSUM=9feafbb5ea0975ab2bcdea7365fffec53dba457a81572bbf091dc28aa538060f
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip
        - GIT_LFS_CHECKSUM=18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5
+
+    - os: linux
+      language: go
+      env:
+       - TARGET_PLATFORM=arm64
+       - GIT_LFS_VERSION=2.3.4
 
 compiler:
   - gcc

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -1,0 +1,28 @@
+echo " -- Building git at $SOURCE to $DESTINATION"
+apt-get update
+apt-get install -y build-essential libexpat-dev libcurl4-openssl-dev zlib1g-dev
+
+cd $SOURCE
+make clean
+DESTDIR="$DESTINATION" make strip install prefix=/ \
+    NO_PERL=1 \
+    NO_TCLTK=1 \
+    NO_GETTEXT=1 \
+    NO_OPENSSL=1 \
+    NO_INSTALL_HARDLINKS=1 \
+    CC='gcc' \
+    CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
+    LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro'
+
+echo "-- Removing server-side programs"
+rm "$DESTINATION/bin/git-cvsserver"
+rm "$DESTINATION/bin/git-receive-pack"
+rm "$DESTINATION/bin/git-upload-archive"
+rm "$DESTINATION/bin/git-upload-pack"
+rm "$DESTINATION/bin/git-shell"
+
+echo "-- Removing unsupported features"
+rm "$DESTINATION/libexec/git-core/git-svn"
+rm "$DESTINATION/libexec/git-core/git-remote-testsvn"
+rm "$DESTINATION/libexec/git-core/git-p4"
+chmod 777 "$DESTINATION/libexec/git-core"

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Compiling Git for Linux and bundling Git LFS from upstream.
+#
+
+SOURCE=$1
+DESTINATION=$2
+BASEDIR=$3
+
+mkdir -p $DESTINATION
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
+docker run -it \
+--mount type=bind,source=$BASEDIR,target=$BASEDIR \
+--mount type=bind,source=$DESTINATION,target=$DESTINATION \
+-e "SOURCE=$SOURCE" \
+-e "DESTINATION=$DESTINATION" \
+-w=$BASEDIR \
+--rm multiarch/debian-debootstrap:arm64-jessie sh $BASEDIR/script/build-arm64-git.sh
+cd - > /dev/null
+
+echo "-- Building Git LFS"
+go get github.com/git-lfs/git-lfs
+GOPATH=`go env GOPATH`
+cd $GOPATH/src/github.com/git-lfs/git-lfs
+git checkout "v${GIT_LFS_VERSION}"
+$GOPATH/src/github.com/git-lfs/git-lfs/script/bootstrap -arch arm64 -os linux
+echo "-- Bundling Git LFS"
+GIT_LFS_FILE=$GOPATH/src/github.com/git-lfs/git-lfs/bin/releases/linux-arm64/git-lfs-$GIT_LFS_VERSION/git-lfs
+SUBFOLDER="$DESTINATION/libexec/git-core"
+cp $GIT_LFS_FILE $SUBFOLDER
+
+# download CA bundle and write straight to temp folder
+# for more information: https://curl.haxx.se/docs/caextract.html
+echo "-- Adding CA bundle"
+cd $DESTINATION
+mkdir -p ssl
+curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
+cd - > /dev/null
+
+
+checkStaticLinking() {
+  if [ -z "$1" ] ; then
+    # no parameter provided, fail hard
+    exit 1
+  fi
+
+  # ermagherd there's two whitespace characters between 'LSB' and 'executable'
+  # when running this on Travis - why is everything so terrible?
+  if file $1 | grep -q 'ELF 64-bit LSB'; then
+    if readelf -d $1 | grep -q 'Shared library'; then
+      echo "File: $file"
+      # this is done twice rather than storing in a bash variable because
+      # it's easier than trying to preserve the line endings
+      readelf -d $1 | grep 'Shared library'
+    fi
+  fi
+}
+
+echo "-- Static linking research"
+cd "$DESTINATION"
+# check all files for ELF exectuables
+find . -type f -print0 | while read -d $'\0' file
+do
+  checkStaticLinking $file
+done
+cd - > /dev/null

--- a/script/build.sh
+++ b/script/build.sh
@@ -4,9 +4,9 @@
 # Platforms have different ways to build Git and prepare the environment
 # for packaging, so defer to the `build-*` files for more details
 #
-
+BASEDIR=`pwd`
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SOURCE="./git"
+SOURCE="${BASEDIR}/git"
 DESTINATION="/tmp/build/git"
 
 if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
@@ -15,6 +15,8 @@ elif [ "$TARGET_PLATFORM" == "macOS" ]; then
   bash "$DIR/build-macos.sh" $SOURCE $DESTINATION
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
   bash "$DIR/build-win32.sh" $DESTINATION
+elif [ "$TARGET_PLATFORM" == "arm64" ]; then
+  bash "$DIR/build-arm64.sh" $SOURCE $DESTINATION $BASEDIR
 else
   echo "Unable to build Git for platform $TARGET_PLATFORM"
   exit 1

--- a/script/package.sh
+++ b/script/package.sh
@@ -39,6 +39,9 @@ elif [ "$TARGET_PLATFORM" == "macOS" ]; then
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
   GZIP_FILE="dugite-native-$VERSION-win32-$BUILD.tar.gz"
   LZMA_FILE="dugite-native-$VERSION-win32-$BUILD.lzma"
+elif [ "$TARGET_PLATFORM" == "arm64" ]; then
+  GZIP_FILE="dugite-native-$VERSION-arm64-$BUILD.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-arm64-$BUILD.lzma"
 else
   echo "Unable to package Git for platform $TARGET_PLATFORM"
   exit 1


### PR DESCRIPTION
This PR adds an arm64 build for dugite.  
Unfortunately git-lfs doesn't have a prebuilt arm64 binary (see https://github.com/git-lfs/git-lfs/issues/2464 for more details), so the arm64 dugite-native build works as follows:

1. Git is build via a multiarch/debian-debootstrap:arm64-jessie docker container.  This allows cross compilation of arm64 git on a x86 machine.
2. git-lfs is built using the arch flag, eg: `git-lfs/script/bootstrap -arch arm64 -os linux`