### PR TITLE
Update to Git 2.16.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
       language: c
       env:
        - TARGET_PLATFORM=win32
-       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.16.0.windows.2/MinGit-2.16.0.2-64-bit.zip
-       - GIT_FOR_WINDOWS_CHECKSUM=fb028d2a18c7ec18f8febecafc95e9dad0dd583ab8fe376c95a06eff62058bbd
+       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.1/MinGit-2.16.1-64-bit.zip
+       - GIT_FOR_WINDOWS_CHECKSUM=14fde7abfa14f505605517b00c8b1bf09eec78e3653516f30dc43084d8df7ede
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip
        - GIT_LFS_CHECKSUM=18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ skip_branch_with_pr: true
 
 environment:
   TARGET_PLATFORM: win32
-  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.16.0.windows.2/MinGit-2.16.0.2-64-bit.zip
-  GIT_FOR_WINDOWS_CHECKSUM: fb028d2a18c7ec18f8febecafc95e9dad0dd583ab8fe376c95a06eff62058bbd
+  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.1/MinGit-2.16.1-64-bit.zip
+  GIT_FOR_WINDOWS_CHECKSUM: 14fde7abfa14f505605517b00c8b1bf09eec78e3653516f30dc43084d8df7ede
   GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip
   GIT_LFS_CHECKSUM: 18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5
 

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -5,8 +5,8 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.16.0.windows.2/MinGit-2.16.0.2-64-bit.zip \
-GIT_FOR_WINDOWS_CHECKSUM=fb028d2a18c7ec18f8febecafc95e9dad0dd583ab8fe376c95a06eff62058bbd \
+GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.1/MinGit-2.16.1-64-bit.zip \
+GIT_FOR_WINDOWS_CHECKSUM=14fde7abfa14f505605517b00c8b1bf09eec78e3653516f30dc43084d8df7ede \
 GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip \
 GIT_LFS_CHECKSUM=18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5 \
 . "$ROOT/script/build-win32.sh" $SOURCE $DESTINATION


### PR DESCRIPTION
A minor release due to an upstream segfault discovered when cloning a repository which tracks two paths that differ only in case on a case insensitive filesystem.

 - [Git release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.16.1.txt)
 - [Git for Windows release notes](https://github.com/git-for-windows/git/releases/tag/v2.16.1.windows.1)