### PR TITLE
[WIP] migrate macOS build over to VSTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,6 @@ matrix:
         - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-linux-amd64-2.3.4.tar.gz
         - GIT_LFS_CHECKSUM=6755e109a85ffd9a03aacc629ea4ab1cbb8e7d83e41bd1880bf44b41927f4cfe
 
-    - os: osx
-      language: c
-      env:
-       - TARGET_PLATFORM=macOS
-       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-darwin-amd64-2.3.4.tar.gz
-       - GIT_LFS_CHECKSUM=b16d4b7469b1fa34e0e27bedb1b77cc425b8d7903264854e5f18b0bc73576edb
-
     - os: linux
       language: c
       env:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,0 +1,11 @@
+steps:
+- bash: script/build.sh
+  displayName: Build step
+  env:
+    TARGET_PLATFORM: macOS
+    GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-darwin-amd64-2.3.4.tar.gz
+    GIT_LFS_CHECKSUM: b16d4b7469b1fa34e0e27bedb1b77cc425b8d7903264854e5f18b0bc73576edb
+- bash: script/package.sh
+  displayName: Package step
+  env:
+    TARGET_PLATFORM: macOS

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,10 +1,13 @@
 steps:
+- script: git submodule update --init --recursive
+
 - bash: script/build.sh
   displayName: Build step
   env:
     TARGET_PLATFORM: macOS
     GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-darwin-amd64-2.3.4.tar.gz
     GIT_LFS_CHECKSUM: b16d4b7469b1fa34e0e27bedb1b77cc425b8d7903264854e5f18b0bc73576edb
+
 - bash: script/package.sh
   displayName: Package step
   env:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,5 +1,4 @@
 steps:
-- script: git submodule update --init --recursive
 
 - bash: script/build.sh
   displayName: Build step

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -24,6 +24,8 @@ computeChecksum() {
 
 echo "-- Building git at $SOURCE to $DESTINATION"
 
+mkdir -p $DESTINATION
+
 cd $SOURCE
 make clean
 DESTDIR="$DESTINATION" make strip install prefix=/ \


### PR DESCRIPTION
![](https://media.giphy.com/media/xDQ3Oql1BN54c/giphy.gif)

 - [x] get build step passing
 - [x] get package step passing
 - [x] need to enable bash 3 for these scripts (or rewrite script to run on bash 2?)
 - [x] get VSTS to use this build script, not what's defined in the UI
 - [ ] get commit status integration working
 - [ ] build logs should be visible without requiring login
 - [ ] incrementing build number isn't flowing through to package output

```
2018-01-22T23:00:33.9988340Z Packages created:
2018-01-22T23:00:34.0024460Z dugite-native-v2.16.0-macOS-.tar.gz -  13M - checksum: 60fb08e192e3e09fbb1fa716fbb511de73da002da724ef5749fa888ff20d57bf
2018-01-22T23:00:34.0064110Z dugite-native-v2.16.0-macOS-.lzma - 5.0M - checksum: b7fb9b7135b4dc3c134d3c2725e6d841fd1324191a0d060fd2fc98c1d78e0614
2018-01-22T23:00:34.0954090Z ##[section]Finishing: Package Step
```

 - [ ] if tagged build, publish to GitHub release
 - [ ] ???