### PR TITLE
Force .sh files have LF ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.sh text eol=lf


### PR DESCRIPTION
I tried to build this on windows via bash on windows. But then I got this:

```bash
test/win32.sh: line 2: $'\r': command not found
test/win32.sh: line 7: $'\r': command not found
....(truncated)
```

I manage to solve this by removing all `\r`. So i think `.sh` files have to be enforced to have LF line ending.