### PR TITLE
bump Git and Git for Windows to 2.16.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
       language: c
       env:
        - TARGET_PLATFORM=win32
-       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.1/MinGit-2.16.1-64-bit.zip
-       - GIT_FOR_WINDOWS_CHECKSUM=14fde7abfa14f505605517b00c8b1bf09eec78e3653516f30dc43084d8df7ede
+       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip
+       - GIT_FOR_WINDOWS_CHECKSUM=f4ac4e7d53d599d515e905824240cc2b82f3e2c294a872bb650e44b7e89cae8c
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip
        - GIT_LFS_CHECKSUM=18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ skip_branch_with_pr: true
 
 environment:
   TARGET_PLATFORM: win32
-  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.1/MinGit-2.16.1-64-bit.zip
-  GIT_FOR_WINDOWS_CHECKSUM: 14fde7abfa14f505605517b00c8b1bf09eec78e3653516f30dc43084d8df7ede
+  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip
+  GIT_FOR_WINDOWS_CHECKSUM: f4ac4e7d53d599d515e905824240cc2b82f3e2c294a872bb650e44b7e89cae8c
   GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip
   GIT_LFS_CHECKSUM: 18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5
 


### PR DESCRIPTION
 - [Git release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.16.2.txt)
 - [Git for Windows release notes](https://github.com/git-for-windows/git/releases/tag/v2.16.2.windows.1)