### PR TITLE
update to Git LFS 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ matrix:
       language: c
       env:
         - TARGET_PLATFORM=ubuntu
-        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-linux-amd64-2.3.4.tar.gz
-        - GIT_LFS_CHECKSUM=6755e109a85ffd9a03aacc629ea4ab1cbb8e7d83e41bd1880bf44b41927f4cfe
+        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.0/git-lfs-linux-amd64-2.4.0.tar.gz
+        - GIT_LFS_CHECKSUM=56728ec9219c1a9339e1e6166f551459d74d300a29b51031851759cee4d7d710
 
     - os: osx
       language: c
       env:
        - TARGET_PLATFORM=macOS
-       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-darwin-amd64-2.3.4.tar.gz
-       - GIT_LFS_CHECKSUM=b16d4b7469b1fa34e0e27bedb1b77cc425b8d7903264854e5f18b0bc73576edb
+       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.0/git-lfs-darwin-amd64-2.4.0.tar.gz
+       - GIT_LFS_CHECKSUM=ab5a1391316aa9b4fd53fc6e1a2650580b543105429548bb991d6688511f2273
 
     - os: linux
       language: c
@@ -25,14 +25,14 @@ matrix:
        - TARGET_PLATFORM=win32
        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip
        - GIT_FOR_WINDOWS_CHECKSUM=f4ac4e7d53d599d515e905824240cc2b82f3e2c294a872bb650e44b7e89cae8c
-       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip
-       - GIT_LFS_CHECKSUM=18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5
+       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.0/git-lfs-windows-amd64-2.4.0.zip
+       - GIT_LFS_CHECKSUM=e3dec7cd1316ef3dc5f0e99161aa2fe77aea82e1dd57a74e3ecbb1e7e459b10e
 
     - os: linux
       language: go
       env:
        - TARGET_PLATFORM=arm64
-       - GIT_LFS_VERSION=2.3.4
+       - GIT_LFS_VERSION=2.4.0
 
 compiler:
   - gcc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ environment:
   TARGET_PLATFORM: win32
   GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip
   GIT_FOR_WINDOWS_CHECKSUM: f4ac4e7d53d599d515e905824240cc2b82f3e2c294a872bb650e44b7e89cae8c
-  GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.3.4/git-lfs-windows-amd64-2.3.4.zip
-  GIT_LFS_CHECKSUM: 18c47fd2806659e81a40fbd6f6b0598ea1802635ce04fb2317d75973450a3fe5
+  GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.4.0/git-lfs-windows-amd64-2.4.0.zip
+  GIT_LFS_CHECKSUM: e3dec7cd1316ef3dc5f0e99161aa2fe77aea82e1dd57a74e3ecbb1e7e459b10e
 
 build_script:
   - cmd: git submodule update --init --recursive


### PR DESCRIPTION
- [Git LFS release notes](https://github.com/git-lfs/git-lfs/releases/tag/v2.4.0)