### PR TITLE
bump Git package to 2.16.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
       language: c
       env:
        - TARGET_PLATFORM=win32
-       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip
-       - GIT_FOR_WINDOWS_CHECKSUM=f4ac4e7d53d599d515e905824240cc2b82f3e2c294a872bb650e44b7e89cae8c
+       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.16.3.windows.1/MinGit-2.16.3-64-bit.zip
+       - GIT_FOR_WINDOWS_CHECKSUM=74724a54a456be73df94a4ea44a62bee9b2ff00baafda2936bf5b4e61c79209d
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.0/git-lfs-windows-amd64-2.4.0.zip
        - GIT_LFS_CHECKSUM=e3dec7cd1316ef3dc5f0e99161aa2fe77aea82e1dd57a74e3ecbb1e7e459b10e
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ skip_branch_with_pr: true
 
 environment:
   TARGET_PLATFORM: win32
-  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/MinGit-2.16.2-64-bit.zip
-  GIT_FOR_WINDOWS_CHECKSUM: f4ac4e7d53d599d515e905824240cc2b82f3e2c294a872bb650e44b7e89cae8c
+  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.16.3.windows.1/MinGit-2.16.3-64-bit.zip
+  GIT_FOR_WINDOWS_CHECKSUM: 74724a54a456be73df94a4ea44a62bee9b2ff00baafda2936bf5b4e61c79209d
   GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.4.0/git-lfs-windows-amd64-2.4.0.zip
   GIT_LFS_CHECKSUM: e3dec7cd1316ef3dc5f0e99161aa2fe77aea82e1dd57a74e3ecbb1e7e459b10e
 


### PR DESCRIPTION
 - [Git release notes](https://github.com/git-for-windows/git/releases/tag/v2.16.3.windows.1)
 - [Git for Windows release notes](https://github.com/git-for-windows/git/releases/tag/v2.16.3.windows.1)