### PR TITLE
bump to latest Git to address security issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
       language: c
       env:
        - TARGET_PLATFORM=win32
-       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.17.0.windows.1/MinGit-2.17.0-64-bit.zip
-       - GIT_FOR_WINDOWS_CHECKSUM=14c780bfc7af2bb85f6860fd1927402c87393201b7639e5bc3ce0fdc5688931e
+       - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.17.1.windows.2/MinGit-2.17.1.2-64-bit.zip
+       - GIT_FOR_WINDOWS_CHECKSUM=52e611a411cd58eaaab8218bb917cb4410b0c5733f234be6e581c6a9821b30ea
        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.0/git-lfs-windows-amd64-2.4.0.zip
        - GIT_LFS_CHECKSUM=e3dec7cd1316ef3dc5f0e99161aa2fe77aea82e1dd57a74e3ecbb1e7e459b10e
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ skip_branch_with_pr: true
 
 environment:
   TARGET_PLATFORM: win32
-  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.17.0.windows.1/MinGit-2.17.0-64-bit.zip
-  GIT_FOR_WINDOWS_CHECKSUM: 14c780bfc7af2bb85f6860fd1927402c87393201b7639e5bc3ce0fdc5688931e
+  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.17.1.windows.2/MinGit-2.17.1.2-64-bit.zip
+  GIT_FOR_WINDOWS_CHECKSUM: 52e611a411cd58eaaab8218bb917cb4410b0c5733f234be6e581c6a9821b30ea
   GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.4.0/git-lfs-windows-amd64-2.4.0.zip
   GIT_LFS_CHECKSUM: e3dec7cd1316ef3dc5f0e99161aa2fe77aea82e1dd57a74e3ecbb1e7e459b10e
 


### PR DESCRIPTION
This upgrades Git to 2.17.1 which also addresses CVE 2018-11235.