### PR TITLE
Unset the http.sslCAInfo system-level config variable on Windows

### DIFF
--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -57,7 +57,11 @@ git config --file $SYSTEM_CONFIG core.symlinks "false"
 git config --file $SYSTEM_CONFIG core.autocrlf "true"
 git config --file $SYSTEM_CONFIG core.fscache "true"
 git config --file $SYSTEM_CONFIG http.sslBackend "schannel"
-
+# See https://github.com/desktop/desktop/issues/4817#issuecomment-393241303
+# Even though it's not set openssl will auto-discover the one we ship because
+# it sits in the right location already. So users manually switching
+# http.sslBackend to openssl will still pick it up.
+git config --file $SYSTEM_CONFIG --unset http.sslCAInfo
 
 # removing global gitattributes file
 rm "$DESTINATION/mingw64/etc/gitattributes"


### PR DESCRIPTION
See https://github.com/desktop/desktop/issues/4817#issuecomment-393241303

This unset (i.e. removes) the `http.sslCAInfo` default setting from the _system_ level configuration that we ship alongside dugite-native in order for the default behavior of the `schannel` subsystem in curl to be to look inside the Windows certificate store, not in the stock ca bundle.

On GitHub Desktop we want to preserve the behavior of looking in the Windows certificate store because we allow users to add self-signed certificate to that store, see https://github.com/desktop/desktop/pull/2581