### PR TITLE
drop flag and enable linking to OpenSSL again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
         - TARGET_PLATFORM=ubuntu
         - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.2/git-lfs-linux-amd64-2.4.2.tar.gz
         - GIT_LFS_CHECKSUM=29529b6c7afb5f656860d5fad7c054baaeded95ecbda040592a58dbcdbb38fe0
+      addons:
+        apt:
+          packages:
+            - libcurl4-openssl-dev
 
     - os: osx
       language: c

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -1,6 +1,6 @@
 echo " -- Building git at $SOURCE to $DESTINATION"
 apt-get update
-apt-get install -y build-essential libexpat-dev libcurl4-openssl-dev zlib1g-dev
+apt-get install -y build-essential libexpat-dev libcurl4-openssl-dev zlib1g-dev libssl-dev
 
 cd $SOURCE
 make clean

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -8,7 +8,6 @@ DESTDIR="$DESTINATION" make strip install prefix=/ \
     NO_PERL=1 \
     NO_TCLTK=1 \
     NO_GETTEXT=1 \
-    NO_OPENSSL=1 \
     NO_INSTALL_HARDLINKS=1 \
     CC='gcc' \
     CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -30,7 +30,6 @@ DESTDIR="$DESTINATION" make strip install prefix=/ \
     NO_PERL=1 \
     NO_TCLTK=1 \
     NO_GETTEXT=1 \
-    NO_OPENSSL=1 \
     NO_INSTALL_HARDLINKS=1 \
     CC='gcc' \
     CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \


### PR DESCRIPTION
As part of investigation https://github.com/shiftkey/desktop/issues/21 I found myself realising some choices I'd made ages ago were not great:

 - the Ubuntu distribution is compiled and linked with `NO_OPENSSL=1` because I wanted to avoid any unnecessary TLS dependencies
 - it looks like this means it's compiled and linked with _some other_ TLS dependency
 - the vanilla Travis images look like they have multiple `libcurl4-*` dependencies available (and/or installed)

```
$ sudo apt install libcurl4-dev
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package libcurl4-dev is a virtual package provided by:
  libcurl4-openssl-dev 7.47.0-1ubuntu2.8
  libcurl4-nss-dev 7.47.0-1ubuntu2.8
  libcurl4-gnutls-dev 7.47.0-1ubuntu2.8
You should explicitly select one to install.

E: Package 'libcurl4-dev' has no installation candidate
```

 - `libcurl-gnutls.so.4` just isn't published for RedHat-derived distros (Fedora, CentOS, etc) which is why https://github.com/shiftkey/desktop/issues/21 is raised
 - this is the advice on [Git SCM](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) about building from source, and I'm not really sure why they've differed like this:

<img width="679" src="https://user-images.githubusercontent.com/359239/43079848-9cbdcfbc-8e64-11e8-9bf4-aa6c02580b1c.png">

 - the symlink thing is a workaround, and it'd be nice to make this dependency explicit so the package manager can just handle it at install time
 - on Debian-based distros, the `libcurl3` package seems to contain the right shared libraries. For RPM-based distros, it looks like `libcurl` is the right package

So after all that yak shaving, I think I need to make the next update of `dugite-native` just link to OpenSSL and add some proper documentation for distributors about shared libraries that need to be available on the end-user's machines at install time.