### PR TITLE
use single GIT_LFS_VERSION config value rather than multiple URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,16 @@ sudo: required
 services:
   - docker
 
+env:
+  global:
+    - GIT_LFS_VERSION=2.4.2
+
 matrix:
   include:
     - os: linux
       language: c
       env:
         - TARGET_PLATFORM=ubuntu
-        - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.2/git-lfs-linux-amd64-2.4.2.tar.gz
         - GIT_LFS_CHECKSUM=29529b6c7afb5f656860d5fad7c054baaeded95ecbda040592a58dbcdbb38fe0
       addons:
         apt:
@@ -20,7 +23,6 @@ matrix:
       language: c
       env:
        - TARGET_PLATFORM=macOS
-       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.2/git-lfs-darwin-amd64-2.4.2.tar.gz
        - GIT_LFS_CHECKSUM=5efdad9722712c6fc039c1ee824c46b3f3c3f8794b2ef8a9776ff8083a3d5e97
 
     - os: linux
@@ -29,14 +31,12 @@ matrix:
        - TARGET_PLATFORM=win32
        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.18.0.windows.1/MinGit-2.18.0-64-bit.zip
        - GIT_FOR_WINDOWS_CHECKSUM=1dfd05de1320d57f448ed08a07c0b9de2de8976c83840f553440689b5db6a1cf
-       - GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.2/git-lfs-windows-amd64-2.4.2.zip
        - GIT_LFS_CHECKSUM=4c95d8e842ef55013c8ac99c4ffcad2a20a41bc41bd8e0943a228a03e07cd976
 
     - os: linux
       language: go
       env:
        - TARGET_PLATFORM=arm64
-       - GIT_LFS_VERSION=2.4.0
 
 compiler:
   - gcc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   TARGET_PLATFORM: win32
   GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.18.0.windows.1/MinGit-2.18.0-64-bit.zip
   GIT_FOR_WINDOWS_CHECKSUM: 1dfd05de1320d57f448ed08a07c0b9de2de8976c83840f553440689b5db6a1cf
-  GIT_LFS_URL: https://github.com/git-lfs/git-lfs/releases/download/v2.4.2/git-lfs-windows-amd64-2.4.2.zip
+  GIT_LFS_VERSION: 2.4.2
   GIT_LFS_CHECKSUM: 4c95d8e842ef55013c8ac99c4ffcad2a20a41bc41bd8e0943a228a03e07cd976
 
 build_script:

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -37,7 +37,8 @@ cd - > /dev/null
 
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.tar.gz
-curl -sL -o $GIT_LFS_FILE https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-darwin-amd64-$GIT_LFS_VERSION.tar.gz
+GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-darwin-amd64-${GIT_LFS_VERSION}.tar.gz"
+curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -37,7 +37,7 @@ cd - > /dev/null
 
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.tar.gz
-curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
+curl -sL -o $GIT_LFS_FILE https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-darwin-amd64-$GIT_LFS_VERSION.tar.gz
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -38,8 +38,8 @@ cd - > /dev/null
 
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.tar.gz
-curl -sL -o $GIT_LFS_FILE https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-linux-amd64-$GIT_LFS_VERSION.tar.gz
-
+GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz"
+curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
 shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}'
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -40,7 +40,6 @@ echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.tar.gz
 GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-${GIT_LFS_VERSION}.tar.gz"
 curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
-shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}'
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -38,7 +38,8 @@ cd - > /dev/null
 
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.tar.gz
-curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
+curl -sL -o $GIT_LFS_FILE https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-linux-amd64-$GIT_LFS_VERSION.tar.gz
+
 shasum -a 256 $GIT_LFS_FILE | awk '{print $1;}'
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -38,7 +38,7 @@ fi
 # download Git LFS, verify its the right contents, and unpack it
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.zip
-curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
+curl -sL -o $GIT_LFS_FILE https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-windows-amd64-$GIT_LFS_VERSION.zip
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -38,7 +38,8 @@ fi
 # download Git LFS, verify its the right contents, and unpack it
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=git-lfs.zip
-curl -sL -o $GIT_LFS_FILE https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-windows-amd64-$GIT_LFS_VERSION.zip
+GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-windows-amd64-${GIT_LFS_VERSION}.zip"
+curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -3,8 +3,7 @@ const path = require('path')
 const YAML = require('node-yaml')
 
 function writeEnvironmentToFile(os, env) {
-  const otherArgs = env.slice(1)
-  const environmentVariables = otherArgs.map(a => `${a} \\`).join('\n')
+  const environmentVariables = env.map(a => `${a} \\`).join('\n')
 
   const script = `build-${os}.sh`
   const fileContents = `#!/bin/bash
@@ -59,19 +58,23 @@ const travisFile = path.resolve(__dirname, '..', '.travis.yml')
 const yamlText = fs.readFileSync(travisFile)
 const yaml = YAML.parse(yamlText)
 
+const globalEnv = yaml['env']['global']
+
 const platforms = yaml['matrix']['include']
 
 for (const platform of platforms) {
-  const env = platform['env']
-  const target = env[0]
+  const platformEnv = platform['env']
+  const env = [ ... globalEnv, ...platformEnv ]
+
+  const target = platformEnv[0]
   const keys = target.split('=')
   const os = keys[1].toLowerCase()
 
-  if (os === 'ubuntu') {
-    writeEnvironmentToFile(os, env)
-  } else if (os === 'macos') {
-    writeEnvironmentToFile(os, env)
-  } else if (os === 'win32') {
-    writeEnvironmentToFile(os, env)
+  switch (os) {
+    case 'ubuntu':
+    case 'macos':
+    case 'win32':
+      writeEnvironmentToFile(os, env)
+      break
   }
 }

--- a/test/macos.sh
+++ b/test/macos.sh
@@ -5,7 +5,8 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.2/git-lfs-darwin-amd64-2.4.2.tar.gz \
+GIT_LFS_VERSION=2.4.2 \
+TARGET_PLATFORM=macOS \
 GIT_LFS_CHECKSUM=5efdad9722712c6fc039c1ee824c46b3f3c3f8794b2ef8a9776ff8083a3d5e97 \
 . "$ROOT/script/build-macos.sh" $SOURCE $DESTINATION
 

--- a/test/ubuntu.sh
+++ b/test/ubuntu.sh
@@ -5,7 +5,8 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.2/git-lfs-linux-amd64-2.4.2.tar.gz \
+GIT_LFS_VERSION=2.4.2 \
+TARGET_PLATFORM=ubuntu \
 GIT_LFS_CHECKSUM=29529b6c7afb5f656860d5fad7c054baaeded95ecbda040592a58dbcdbb38fe0 \
 . "$ROOT/script/build-ubuntu.sh" $SOURCE $DESTINATION
 

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -5,9 +5,10 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.17.1.windows.2/MinGit-2.17.1.2-64-bit.zip \
-GIT_FOR_WINDOWS_CHECKSUM=52e611a411cd58eaaab8218bb917cb4410b0c5733f234be6e581c6a9821b30ea \
-GIT_LFS_URL=https://github.com/git-lfs/git-lfs/releases/download/v2.4.2/git-lfs-windows-amd64-2.4.2.zip \
+GIT_LFS_VERSION=2.4.2 \
+TARGET_PLATFORM=win32 \
+GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.18.0.windows.1/MinGit-2.18.0-64-bit.zip \
+GIT_FOR_WINDOWS_CHECKSUM=1dfd05de1320d57f448ed08a07c0b9de2de8976c83840f553440689b5db6a1cf \
 GIT_LFS_CHECKSUM=4c95d8e842ef55013c8ac99c4ffcad2a20a41bc41bd8e0943a228a03e07cd976 \
 . "$ROOT/script/build-win32.sh" $SOURCE $DESTINATION
 


### PR DESCRIPTION
This now means I can bump the version in one spot and should prevent me from overlooking the ARM64 build when upgrading Git LFS