### PR TITLE
enable USE_LIBPCRE when building Git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,17 @@ matrix:
       env:
         - TARGET_PLATFORM=ubuntu
         - GIT_LFS_CHECKSUM=c098092be413915793214a570cd51ef46089b6f6616b2f78e35ba374de613b5b
+      addons:
+        apt:
+          packages:
+            - libpcre3-dev
     - os: osx
       language: c
       env:
         - TARGET_PLATFORM=macOS
         - GIT_LFS_CHECKSUM=84ac4953c55bbaf87efd1c3d5b7778b1cf0b257025d2a86d709a2bf301c32c8b
+      before_script:
+        - brew install pcre2
     - os: linux
       language: c
       env:

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get install -y \
     curl \
     zlib1g-dev \
     libssl-dev \
-    gettext
+    gettext \
+    libpcre3-dev
 
 ENV CURL_INSTALL_DIR "/tmp/build/curl"
 ENV CURL_VERSION "curl-7.61.1"

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -25,6 +25,7 @@ make clean
 DESTDIR="$DESTINATION" make strip install prefix=/ \
     NO_PERL=1 \
     NO_TCLTK=1 \
+    USE_LIBPCRE=1 \
     NO_GETTEXT=1 \
     NO_DARWIN_PORTS=1 \
     NO_INSTALL_HARDLINKS=1 \

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -54,6 +54,7 @@ CC='gcc' \
 DESTDIR="$DESTINATION" \
   NO_TCLTK=1 \
   NO_GETTEXT=1 \
+  USE_LIBPCRE1=1 \
   NO_INSTALL_HARDLINKS=1 \
   NO_R_TO_GCC_LINKER=1 \
   make strip install

--- a/script/generate-travis-config.js
+++ b/script/generate-travis-config.js
@@ -76,6 +76,7 @@ function getConfig(
       os: 'osx',
       language: 'c',
       env: ['TARGET_PLATFORM=macOS', `GIT_LFS_CHECKSUM=${lfsFile.checksum}`],
+      before_script: ['brew install pcre2'],
     }
   }
 
@@ -85,6 +86,11 @@ function getConfig(
         os: 'linux',
         language: 'c',
         env: ['TARGET_PLATFORM=ubuntu', `GIT_LFS_CHECKSUM=${lfsFile.checksum}`],
+        addons: {
+          apt: {
+            packages: ['libpcre3-dev'],
+          },
+        },
       }
     } else if (arch === 'arm64') {
       return {


### PR DESCRIPTION
Resolves #74 
 
 - [x] enable for macOS
 - [x] enable for Linux AMD64
 - [ ] enable for Linux ARM64
 - [ ] verify this works as expected on Windows