### PR TITLE
check that git-lfs is found where we expect it

### DIFF
--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -47,7 +47,7 @@ if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   # strip out any text files when extracting the Git LFS archive
   tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude='*.md'
 
-  if [[ ! -f "$DESTINATION/libexec/git-core/git-lfs" ]]; then
+  if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
     echo "After extracting Git LFS the file was not found under libexec/git-core/"
     echo "aborting..."
     exit 1

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -45,7 +45,13 @@ if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
   SUBFOLDER="$DESTINATION/libexec/git-core"
   # strip out any text files when extracting the Git LFS archive
-  tar -xf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude='*.md'  --strip-components=1
+  tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude='*.md' --strip-components=1
+
+  if [[ ! -f "$DESTINATION/libexec/git-core/git-lfs" ]]; then
+    echo "After extracting Git LFS the file was not found under libexec/git-core/"
+    echo "aborting..."
+    exit 1
+  fi
 else
   echo "Git LFS: expected checksum $GIT_LFS_CHECKSUM but got $COMPUTED_SHA256"
   echo "aborting..."

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -45,7 +45,7 @@ if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
   SUBFOLDER="$DESTINATION/libexec/git-core"
   # strip out any text files when extracting the Git LFS archive
-  tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude='*.md' --strip-components=1
+  tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude='*.md'
 
   if [[ ! -f "$DESTINATION/libexec/git-core/git-lfs" ]]; then
     echo "After extracting Git LFS the file was not found under libexec/git-core/"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -45,7 +45,13 @@ COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
   SUBFOLDER="$DESTINATION/libexec/git-core"
-  tar -xf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude="*.md" --strip-components=1
+  tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude="*.md" --strip-components=1
+
+  if [[ ! -f "$DESTINATION/libexec/git-core/git-lfs" ]]; then
+    echo "After extracting Git LFS the file was not found under libexec/git-core/"
+    echo "aborting..."
+    exit 1
+  fi
 else
   echo "Git LFS: expected checksum $GIT_LFS_CHECKSUM but got $COMPUTED_SHA256"
   echo "aborting..."

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -47,7 +47,7 @@ if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   SUBFOLDER="$DESTINATION/libexec/git-core"
   tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude="*.md"
 
-  if [[ ! -f "$DESTINATION/libexec/git-core/git-lfs" ]]; then
+  if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
     echo "After extracting Git LFS the file was not found under libexec/git-core/"
     echo "aborting..."
     exit 1

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -45,7 +45,7 @@ COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
   SUBFOLDER="$DESTINATION/libexec/git-core"
-  tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude="*.md" --strip-components=1
+  tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude="*.md"
 
   if [[ ! -f "$DESTINATION/libexec/git-core/git-lfs" ]]; then
     echo "After extracting Git LFS the file was not found under libexec/git-core/"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -47,7 +47,7 @@ if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   SUBFOLDER="$DESTINATION/mingw64/libexec/git-core/"
   unzip -j $GIT_LFS_FILE -x '*.md' -d $SUBFOLDER
 
-  if [[ ! -f "$DESTINATION/mingw64/libexec/git-core/git-lfs" ]]; then
+  if [[ ! -f "$DESTINATION/mingw64/libexec/git-core/git-lfs.exe" ]]; then
     echo "After extracting Git LFS the file was not found under /mingw64/libexec/git-core/"
     echo "aborting..."
     exit 1

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -44,10 +44,10 @@ curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
 COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
-  SUBFOLDER="$DESTINATION/mingw64/libexec/git-core/"
+  SUBFOLDER="$DESTINATION/mingw64/libexec/git-core"
   unzip -j $GIT_LFS_FILE -x '*.md' -d $SUBFOLDER
 
-  if [[ ! -f "$DESTINATION/mingw64/libexec/git-core/git-lfs.exe" ]]; then
+  if [[ ! -f "$SUBFOLDER/git-lfs.exe" ]]; then
     echo "After extracting Git LFS the file was not found under /mingw64/libexec/git-core/"
     echo "aborting..."
     exit 1

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -45,7 +45,13 @@ COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
   echo "Git LFS: checksums match"
   SUBFOLDER="$DESTINATION/mingw64/libexec/git-core/"
-  unzip -qq -j $GIT_LFS_FILE -x '*.md' -d $SUBFOLDER
+  unzip -j $GIT_LFS_FILE -x '*.md' -d $SUBFOLDER
+
+  if [[ ! -f "$DESTINATION/mingw64/libexec/git-core/git-lfs" ]]; then
+    echo "After extracting Git LFS the file was not found under /mingw64/libexec/git-core/"
+    echo "aborting..."
+    exit 1
+  fi
 else
   echo "Git LFS: expected checksum $GIT_LFS_CHECKSUM and got $COMPUTED_SHA256"
   echo "aborting..."


### PR DESCRIPTION
This adds some resiliency to the Git LFS packaging process by ensuring the `git-lfs` binary is where we expect it when unpacking:

 - [x] verify the bug when unpacking (macOS, Linux)
 - [x] fix the bug by dropping `--strip-components=1`