### PR TITLE
switch ARM64 build over to use new way of building from source

### DIFF
--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -24,7 +24,7 @@ go get github.com/git-lfs/git-lfs
 GOPATH=`go env GOPATH`
 cd $GOPATH/src/github.com/git-lfs/git-lfs
 git checkout "v${GIT_LFS_VERSION}"
-$GOPATH/src/github.com/git-lfs/git-lfs/script/bootstrap -arch arm64 -os linux
+GOARCH=arm64 GOOS=linux make
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=$GOPATH/src/github.com/git-lfs/git-lfs/bin/releases/linux-arm64/git-lfs-$GIT_LFS_VERSION/git-lfs
 SUBFOLDER="$DESTINATION/libexec/git-core"

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -25,7 +25,7 @@ GOPATH=`go env GOPATH`
 cd $GOPATH/src/github.com/git-lfs/git-lfs
 git checkout "v${GIT_LFS_VERSION}"
 ls -l /tmp
-chmod 1777 /tmp
+chmod -R a+x /tmp
 ls -l /tmp
 GOARCH=arm64 GOOS=linux make
 echo "-- Bundling Git LFS"

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -24,6 +24,7 @@ go get github.com/git-lfs/git-lfs
 GOPATH=`go env GOPATH`
 cd $GOPATH/src/github.com/git-lfs/git-lfs
 git checkout "v${GIT_LFS_VERSION}"
+alias go='TMPDIR=~/tmp go'
 GOARCH=arm64 GOOS=linux make
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=$GOPATH/src/github.com/git-lfs/git-lfs/bin/releases/linux-arm64/git-lfs-$GIT_LFS_VERSION/git-lfs

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -24,7 +24,9 @@ go get github.com/git-lfs/git-lfs
 GOPATH=`go env GOPATH`
 cd $GOPATH/src/github.com/git-lfs/git-lfs
 git checkout "v${GIT_LFS_VERSION}"
-alias go='TMPDIR=~/tmp go'
+ls -l /tmp
+chmod 1777 /tmp
+ls -l /tmp
 GOARCH=arm64 GOOS=linux make
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=$GOPATH/src/github.com/git-lfs/git-lfs/bin/releases/linux-arm64/git-lfs-$GIT_LFS_VERSION/git-lfs


### PR DESCRIPTION
Git LFS switched over to using makefiles for building, which means our ARM64 script isn't working currently:

<img width="1010" alt="screen shot 2018-09-25 at 6 21 26 pm" src="https://user-images.githubusercontent.com/359239/46043992-e797c480-c0ef-11e8-8b0f-bf477a85da68.png">

This PR switches us over to use the new way, before I complete #112 