### PR TITLE
no more manual drafting of release notes

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -16,7 +16,7 @@ Examples:
 
 Here's how to release:
 
-0. `git tag {version}` from the commit you wish to create a release
+1. `git tag {version}` from the commit you wish to create a release
 1. `git push origin --tags`
 1. Wait a few minutes for the build to finish
 1. From your machine run this command: `npm run generate-release-notes`
@@ -26,21 +26,20 @@ each of those builds completes, the artefacts are published to a draft release
 on GitHub. The `generate-release-notes` script handles generating the details
 of the release, to save you manually finding the checksums.
 
-This is the template that we previously used:
+This is the template we now use:
 
 ```
-{details about what's changed since the last release}
+ - list of merged pull requests
 
-| File | SHA256 checksum |
-| --- | --- |
-| dugite-native-v{version}-macOS.tar.gz | `{sha1}` |
-| dugite-native-v{version}-macOS.lzma | `{sha2}` |
-| dugite-native-v{version}-ubuntu.tar.gz | `{sha3}` |
-| dugite-native-v{version}-ubuntu.lzma | `{sha4}` |
-| dugite-native-v{version}-win32.tar.gz | `{sha5}` |
-| dugite-native-v{version}-win32.lzma | `{sha6}` |
-| dugite-native-v{version}-arm64.tar.gz | `{sha7}` |
-| dugite-native-v{version}-arm64.lzma | `{sha8}` |
+## SHA-256 hashes:
+
+{filename}
+{checksum of file}
+
+{filename}
+{checksum of file}
+
+...
 ```
 
 The script requires a personal access token with `public_scope` set to the `GITHUB_ACCESS_TOKEN` environment variable, and you need to have `write` permissions to this repository for the script to succeed.
@@ -48,15 +47,10 @@ The script requires a personal access token with `public_scope` set to the `GITH
 A successful run will look like this:
 
 ```
-✅ token found for shiftkey...
-✅ token has 'public_scope' scope to make changes to releases
+✅ Token found for shiftkey...
+✅ Token has 'public_scope' scope to make changes to releases
 ✅ Latest release 'v2.19.0-1' is a draft
-✅ TODO: find merged PRs between v2.19.0 and v2.19.0-1
-release notes: [
-  " - upgrade to Git 2.19.0 and Git LFS 2.5.1 - #110 via @shiftkey",
-  " - Add SHA256 checksums to uploaded artifacts - #111 via @shiftkey",
-  " - switch ARM64 agent over to use new build steps - #114 via @shiftkey"
-]
+✅ Changelog has 4 entries
 ✅ Draft for release v2.19.0-1 updated.
 
 🚨 Please review draft release and publish: https://github.com/desktop/dugite-native/releases/tag/untagged-3c3f4a202dd581133050

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -57,13 +57,16 @@ A successful run will look like this:
 ✅ Token has 'public_scope' scope to make changes to releases
 ✅ Newest release 'v2.19.0-1' is a draft
 ✅ All agents have finished and uploaded artefacts
-✅ Draft for release v2.19.0-1 updated with changelog and artifacts.
+✅ Draft for release v2.19.0-1 updated with changelog and artifacts
 
 🚨 Please review draft release and publish: https://github.com/desktop/dugite-native/releases/tag/untagged-e0327b962d90374b8a57
 ```
 
-You should then browse to the URL, tweak the changelog entries if they are
-unclear, and then press **Publish** to make the release public.
+You should then browse to the URL and confirm the changelog makes sense. Feel
+free to remove any infrastructure changes from the changelog entries, as the
+release should be focused on user-facing changes.
+
+Once you're happy with the release, press **Publish** and you're done :tada:.
 
 The script is very defensive and is designed to be run multiple times before you
 publish. If it encounters a problem it should stop and provide some helpful

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -29,7 +29,8 @@ of the release, to save you manually finding the checksums.
 This is the template we now use:
 
 ```
- - list of merged pull requests
+ - some merged pull request - #ABC via @author
+ - a different pull request - #XYZ via @author
 
 ## SHA-256 hashes:
 
@@ -42,7 +43,9 @@ This is the template we now use:
 ...
 ```
 
-The script requires a personal access token with `public_scope` set to the `GITHUB_ACCESS_TOKEN` environment variable, and you need to have `write` permissions to this repository for the script to succeed.
+The script requires a personal access token with `public_scope` set to the
+`GITHUB_ACCESS_TOKEN` environment variable, and you need to have `write`
+permissions to this repository for the script to succeed.
 
 A successful run will look like this:
 
@@ -59,8 +62,9 @@ A successful run will look like this:
 You should then browse to the URL, tweak the changelog entries if they are
 unclear, and then press **Publish** to make the release public.
 
-The script is very defensive and is designed to be run multiple times. If it
-encounters a problem it should stop and provide some helpful context:
+The script is very defensive and is designed to be run multiple times before you
+publish. If it encounters a problem it should stop and provide some helpful
+context:
 
 ```
 ✅ token found for shiftkey...

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,9 +3,10 @@
 All releases are published using GitHub releases. Anyone with push access to the
 repository can create a new release.
 
-### Versioning Scheme
+### Versioning
 
-We should follow Git's versioning scheme, and increment the build number for other changes like incremementing Git LFS or packaging changes
+We should follow Git's versioning scheme, and only increment the build number for
+other changes like incremementing Git LFS or packaging changes
 
 Examples:
 
@@ -14,17 +15,15 @@ Examples:
 
 ### Release Process
 
-Here's how to release:
-
-1. `git tag {version}` from the commit you wish to create a release
-1. `git push origin --tags`
+1. `git tag {version}` the version you wish to publish 
+1. `git push origin --tags` to start off the release build
 1. Wait a few minutes for the build to finish
 1. From your machine run this command: `npm run generate-release-notes`
 
 Pushing the tag triggers a new build for the platforms we need to support. As
 each of those builds completes, the artefacts are published to a draft release
-on GitHub. The `generate-release-notes` script handles generating the details
-of the release, to save you manually finding the checksums.
+on GitHub. The `generate-release-notes` script handles generating the changelog
+for the release, and saves you manually finding and adding the checksums.
 
 This is the template we now use:
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -50,13 +50,16 @@ permissions to this repository for the script to succeed.
 A successful run will look like this:
 
 ```
-✅ Token found for shiftkey...
-✅ Token has 'public_scope' scope to make changes to releases
-✅ Latest release 'v2.19.0-1' is a draft
-✅ Changelog has 4 entries
-✅ Draft for release v2.19.0-1 updated.
+> dugite-native@ generate-release-notes /Users/shiftkey/src/dugite-native
+> node script/generate-release-notes.js
 
-🚨 Please review draft release and publish: https://github.com/desktop/dugite-native/releases/tag/untagged-3c3f4a202dd581133050
+✅ Token found for shiftkey
+✅ Token has 'public_scope' scope to make changes to releases
+✅ Newest release 'v2.19.0-1' is a draft
+✅ All agents have finished and uploaded artefacts
+✅ Draft for release v2.19.0-1 updated with changelog and artifacts.
+
+🚨 Please review draft release and publish: https://github.com/desktop/dugite-native/releases/tag/untagged-e0327b962d90374b8a57
 ```
 
 You should then browse to the URL, tweak the changelog entries if they are
@@ -67,8 +70,8 @@ publish. If it encounters a problem it should stop and provide some helpful
 context:
 
 ```
-✅ token found for shiftkey...
-✅ token has 'public_scope' scope to make changes to releases...
-✅ Latest release 'v2.19.0-1' is a draft...
-🔴 Draft has 16 assets, expecting 20. This means the build agents are probably still going.
+✅ Token found for shiftkey
+✅ Token has 'public_scope' scope to make changes to releases
+✅ Latest release 'v2.19.0-1' is a draft
+🔴 Draft has 16 assets, expecting 20. This means the build agents are probably still going...
 ```

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -48,7 +48,18 @@ The script requires a personal access token with `public_scope` set to the `GITH
 A successful run will look like this:
 
 ```
+✅ token found for shiftkey...
+✅ token has 'public_scope' scope to make changes to releases
+✅ Latest release 'v2.19.0-1' is a draft
+✅ TODO: find merged PRs between v2.19.0 and v2.19.0-1
+release notes: [
+  " - upgrade to Git 2.19.0 and Git LFS 2.5.1 - #110 via @shiftkey",
+  " - Add SHA256 checksums to uploaded artifacts - #111 via @shiftkey",
+  " - switch ARM64 agent over to use new build steps - #114 via @shiftkey"
+]
+✅ Draft for release v2.19.0-1 updated.
 
+🚨 Please review draft release and publish: https://github.com/desktop/dugite-native/releases/tag/untagged-3c3f4a202dd581133050
 ```
 
 A problem found will stop the script with some helpful context:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -56,7 +56,11 @@ A successful run will look like this:
 🚨 Please review draft release and publish: https://github.com/desktop/dugite-native/releases/tag/untagged-3c3f4a202dd581133050
 ```
 
-A problem found will stop the script with some helpful context:
+You should then browse to the URL, tweak the changelog entries if they are
+unclear, and then press **Publish** to make the release public.
+
+The script is very defensive and is designed to be run multiple times. If it
+encounters a problem it should stop and provide some helpful context:
 
 ```
 ✅ token found for shiftkey...
@@ -64,5 +68,3 @@ A problem found will stop the script with some helpful context:
 ✅ Latest release 'v2.19.0-1' is a draft...
 🔴 Draft has 16 assets, expecting 20. This means the build agents are probably still going.
 ```
-
-You can then look at the URL specified in the build script, verify it's good, and hit Publish to create the release.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,19 +1,32 @@
 # Releases
 
-All releases are published using GitHub releases. Anyone with push access to the repository can create a new release.
+All releases are published using GitHub releases. Anyone with push access to the
+repository can create a new release.
+
+### Versioning Scheme
+
+We should follow Git's versioning scheme, and increment the build number for other changes like incremementing Git LFS or packaging changes
+
+Examples:
+
+- testing - `v2.12.0-rc0`
+- stable - `v2.12.0-1`
+
+### Release Process
 
 Here's how to release:
 
-0. `git tag {version}` from the current `master` commit
-0. `git push origin --tags`
-0. Wait a few minutes for the builds to start and finish
-0. Edit the release notes on the tagged GitHub release
+0. `git tag {version}` from the commit you wish to create a release
+1. `git push origin --tags`
+1. Wait a few minutes for the build to finish
+1. From your machine run this command: `npm run generate-release-notes`
 
-### What Actually Happened?
+Pushing the tag triggers a new build for the platforms we need to support. As
+each of those builds completes, the artefacts are published to a draft release
+on GitHub. The `generate-release-notes` script handles generating the details
+of the release, to save you manually finding the checksums.
 
-Pushing the tag triggers a new build for the platforms we need to support. As each of those builds completes, the artefacts are published to a new release associated with the tag. The naming of the release is still manual, and each build agent will display the SHA-256 checksum for it's file in the build.
-
-To speed up the manual work, here's the Markdown you should use for the release body (just replace the `{placeholder}` values):
+This is the template that we previously used:
 
 ```
 {details about what's changed since the last release}
@@ -30,11 +43,21 @@ To speed up the manual work, here's the Markdown you should use for the release 
 | dugite-native-v{version}-arm64.lzma | `{sha8}` |
 ```
 
-### Versioning Scheme
+The script requires a personal access token with `public_scope` set to the `GITHUB_ACCESS_TOKEN` environment variable, and you need to have `write` permissions to this repository for the script to succeed.
 
-Follow Git's versioning, but always have something after to indicate what our customizations look like. Use [Semver](http://semver.org/) for this.
+A successful run will look like this:
 
-Examples:
+```
 
- - testing - `v2.12.0-rc0`
- - stable - `v2.12.0-1`
+```
+
+A problem found will stop the script with some helpful context:
+
+```
+✅ token found for shiftkey...
+✅ token has 'public_scope' scope to make changes to releases...
+✅ Latest release 'v2.19.0-1' is a draft...
+🔴 Draft has 16 assets, expecting 20. This means the build agents are probably still going.
+```
+
+You can then look at the URL specified in the build script, verify it's good, and hit Publish to create the release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,17 @@
         "es6-promisify": "^5.0.0"
       }
     },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
@@ -35,20 +46,88 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "before-after-hook": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
       "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+    },
+    "bluebird": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "btoa-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "debug": {
       "version": "3.2.5",
@@ -56,6 +135,21 @@
       "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
       "requires": {
         "ms": "^2.1.1"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "es6-promise": {
@@ -75,6 +169,73 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        }
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "requires": {
+        "ajv": "^5.3.0",
+        "har-schema": "^2.0.0"
+      }
     },
     "http-proxy-agent": {
       "version": "2.1.0",
@@ -100,6 +261,16 @@
         }
       }
     },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
     "https-proxy-agent": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
@@ -109,6 +280,16 @@
         "debug": "^3.1.0"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "js-yaml": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
@@ -116,6 +297,38 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "junk": {
@@ -132,6 +345,19 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
       "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+    },
+    "mime-db": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+    },
+    "mime-types": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+      "requires": {
+        "mime-db": "~1.36.0"
+      }
     },
     "ms": {
       "version": "2.1.1",
@@ -154,6 +380,11 @@
         "promise-fs": "1.2.3"
       }
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "os-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
@@ -162,6 +393,11 @@
         "macos-release": "^1.0.0",
         "win-release": "^1.0.0"
       }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
@@ -190,6 +426,77 @@
         "pinkie-promise": "2.0.1"
       }
     },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
@@ -199,6 +506,50 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "universal-user-agent": {
       "version": "2.0.1",
@@ -212,6 +563,21 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "win-release": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,37 +3,145 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@octokit/rest": {
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.12.0.tgz",
+      "integrity": "sha512-5wRag4kHRkp0JDo++L9x9FkDlHEALbLnbSede16D8u+a2/t+gX32uhDs8cukVLyyrZR79nmh1lNpxZmffwoNoQ==",
+      "requires": {
+        "before-after-hook": "^1.1.0",
+        "btoa-lite": "^1.0.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.0",
+        "lodash": "^4.17.4",
+        "node-fetch": "^2.1.1",
+        "universal-user-agent": "^2.0.0",
+        "url-template": "^2.0.8"
+      }
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
+    },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
+    "debug": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      }
     },
     "js-yaml": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
       "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "junk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/junk/-/junk-2.1.0.tgz",
       "integrity": "sha1-9DG0t/By3FAKXxDOf07HGTDnATQ="
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "macos-release": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "node-fetch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
     },
     "node-yaml": {
       "version": "3.1.1",
@@ -44,6 +152,15 @@
         "js-yaml": "3.9.1",
         "junk": "2.1.0",
         "promise-fs": "1.2.3"
+      }
+    },
+    "os-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+      "requires": {
+        "macos-release": "^1.0.0",
+        "win-release": "^1.0.0"
       }
     },
     "pify": {
@@ -61,7 +178,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "promise-fs": {
@@ -73,10 +190,36 @@
         "pinkie-promise": "2.0.1"
       }
     },
+    "semver": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "universal-user-agent": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.1.tgz",
+      "integrity": "sha512-vz+heWVydO0iyYAa65VHD7WZkYzhl7BeNVy4i54p4TF8OMiLSXdbuQe4hm+fmWAsL+rVibaQHXfhvkw3c1Ws2w==",
+      "requires": {
+        "os-name": "^2.0.1"
+      }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
+    "win-release": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+      "requires": {
+        "semver": "^5.0.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "homepage": "https://github.com/desktop/dugite-native#readme",
   "dependencies": {
     "@octokit/rest": "^15.12.0",
-    "node-yaml": "^3.1.1"
+    "node-yaml": "^3.1.1",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "dugite-native",
   "description": "ad-hoc scripts for helping to contribute",
   "scripts": {
-    "update-test-harness": "node script/update-test-harness.js"
+    "update-test-harness": "node script/update-test-harness.js",
+    "generate-release-notes": "node script/generate-release-notes.js"
   },
   "repository": {
     "type": "git",
@@ -15,6 +16,7 @@
   },
   "homepage": "https://github.com/desktop/dugite-native#readme",
   "dependencies": {
+    "@octokit/rest": "^15.12.0",
     "node-yaml": "^3.1.1"
   }
 }

--- a/script/generate-release-notes.js
+++ b/script/generate-release-notes.js
@@ -13,7 +13,7 @@ process.on("unhandledRejection", reason => {
 async function run() {
   const token = process.env.GITHUB_ACCESS_TOKEN;
   if (token == null) {
-    console.log(`🔴 No GITHUB_ACCESS_TOKEN environment variable set.`);
+    console.log(`🔴 No GITHUB_ACCESS_TOKEN environment variable set`);
     return;
   }
 
@@ -25,7 +25,7 @@ async function run() {
   const user = await octokit.users.get();
   const me = user.data.login;
 
-  console.log(`✅ token found for ${me}...`);
+  console.log(`✅ Token found for ${me}`);
   const foundScopes = user.headers["x-oauth-scopes"];
   if (foundScopes.indexOf("public_repo") === -1) {
     console.log(
@@ -37,7 +37,7 @@ async function run() {
   const owner = "desktop";
   const repo = "dugite-native";
 
-  console.log(`✅ token has 'public_scope' scope to make changes to releases`);
+  console.log(`✅ Token has 'public_scope' scope to make changes to releases`);
 
   const releases = await octokit.repos.getReleases({
     owner,
@@ -50,11 +50,11 @@ async function run() {
   const { tag_name, draft, id } = release;
 
   if (!draft) {
-    console.log(`🔴 Latest published release '${tag_name}' is not a draft.`);
+    console.log(`🔴 Latest published release '${tag_name}' is not a draft`);
     return;
   }
 
-  console.log(`✅ Latest release '${tag_name}' is a draft`);
+  console.log(`✅ Newest release '${tag_name}' is a draft`);
 
   const assets = await octokit.repos.getAssets({
     owner,
@@ -66,10 +66,12 @@ async function run() {
     console.log(
       `🔴 Draft has ${
         assets.data.length
-      } assets, expecting ${SUCCESSFUL_RELEASE_FILE_COUNT}. This means the build agents are probably still going.`
+      } assets, expecting ${SUCCESSFUL_RELEASE_FILE_COUNT}. This means the build agents are probably still going...`
     );
     return;
   }
+
+  console.log(`✅ All agents have finished and uploaded artefacts`);
 
   const entries = [];
 
@@ -99,10 +101,6 @@ async function run() {
   });
 
   const latestReleaseTag = latestRelease.data.tag_name;
-
-  console.log(
-    `✅ TODO: find merged PRs between ${latestReleaseTag} and ${tag_name}`
-  );
 
   const response = await octokit.repos.compareCommits({
     owner,
@@ -164,7 +162,9 @@ ${fileListText}`;
 
   const { html_url } = result.data;
 
-  console.log(`✅ Draft for release ${tag_name} updated.`);
+  console.log(
+    `✅ Draft for release ${tag_name} updated with changelog and artifacts`
+  );
   console.log();
   console.log(`🚨 Please review draft release and publish: ${html_url}`);
 }

--- a/script/generate-release-notes.js
+++ b/script/generate-release-notes.js
@@ -34,18 +34,22 @@ async function run() {
     `✅ token has 'public_scope' scope to make changes to releases...`
   );
 
-  const release = await octokit.repos.getLatestRelease({
+  const releases = await octokit.repos.getReleases({
     owner: "desktop",
-    repo: "dugite-native"
+    repo: "dugite-native",
+    per_page: 1,
+    page: 1
   });
 
-  console.log(`id: ${release.data.id}`);
-  console.log(`tag name: ${release.data.tag_name}`);
-  console.log(`draft: ${release.data.draft}`);
+  const release = releases.data[0];
 
-  const tag = release.data.tag_name;
+  console.log(`id: ${release.id}`);
+  console.log(`tag name: ${release.tag_name}`);
+  console.log(`draft: ${release.draft}`);
 
-  if (release.data.draft === false) {
+  const tag = release.tag_name;
+
+  if (release.draft === false) {
     throw new Error(
       `Latest published release ${tag} is not a draft. Aborting...`
     );
@@ -54,14 +58,14 @@ async function run() {
   const assets = await octokit.repos.getAssets({
     owner: "desktop",
     repo: "dugite-native",
-    release_id: release.data.id
+    release_id: release.id
   });
 
   if (assets.data.length !== SUCCESSFUL_RELEASE_FILE_COUNT) {
     throw new Error(
       `Latest draft release ${tag} has ${
         assets.data.length
-      } files, expected ${SUCCESSFUL_RELEASE_FILE_COUNT}. Aborting...`
+      } files, expecting ${SUCCESSFUL_RELEASE_FILE_COUNT}. The builds are probably still going. Aborting...`
     );
   }
 

--- a/script/generate-release-notes.js
+++ b/script/generate-release-notes.js
@@ -103,18 +103,16 @@ async function run() {
 
   // TODO: find PRs merged between latest release and this one
 
-  const fileList = entries.map(e => `| ${e.fileName} | ${e.checksum} |`);
+  const fileList = entries.map(e => `**${e.fileName}**\n${e.checksum}\n`);
   const fileListText = fileList.join("\n");
   const draftReleaseNotes = `**TODO:** details about what's changed since the last release
 
-| File | SHA256 checksum |
-| --- | --- |
+## SHA-256 hashes:
+
 ${fileListText}`;
 
   console.log(`✅ Draft for latest release ${tag_name}:`);
   console.log(draftReleaseNotes);
-
-  // TODO: ask user if they want to update it on GitHub
 
   const numberWithoutPrefix = tag_name.substring(1);
 
@@ -130,7 +128,7 @@ ${fileListText}`;
   const { html_url } = result.data;
 
   console.log(
-    `✅ Draft for release ${tag_name} updated. Visit ${html_url} to add changelog and publish...`
+    `✅ Draft for release ${tag_name} updated. Plase validate and publish: ${html_url}`
   );
 }
 

--- a/script/generate-release-notes.js
+++ b/script/generate-release-notes.js
@@ -165,7 +165,8 @@ ${fileListText}`;
   const { html_url } = result.data;
 
   console.log(`✅ Draft for release ${tag_name} updated.`);
-  console.log(`Plase validate release and publish: ${html_url}`);
+  console.log();
+  console.log(`🚨 Please validate release and publish: ${html_url}`);
 }
 
 run();

--- a/script/generate-release-notes.js
+++ b/script/generate-release-notes.js
@@ -166,7 +166,7 @@ ${fileListText}`;
 
   console.log(`✅ Draft for release ${tag_name} updated.`);
   console.log();
-  console.log(`🚨 Please validate release and publish: ${html_url}`);
+  console.log(`🚨 Please review draft release and publish: ${html_url}`);
 }
 
 run();

--- a/script/generate-release-notes.js
+++ b/script/generate-release-notes.js
@@ -1,5 +1,10 @@
 const octokit = require("@octokit/rest")();
 
+// five targeted OS/arch combinations
+// two files for each targeted OS/arch
+// two checksum files for the previous
+const SUCCESSFUL_RELEASE_FILE_COUNT = 5 * 2 * 2;
+
 process.on("unhandledRejection", (reason, p) => {
   console.log("Unhandled Rejection, reason:", reason);
 });
@@ -38,21 +43,51 @@ async function run() {
   console.log(`tag name: ${release.data.tag_name}`);
   console.log(`draft: ${release.data.draft}`);
 
+  const tag = release.data.tag_name;
+
+  if (release.data.draft === false) {
+    throw new Error(
+      `Latest published release ${tag} is not a draft. Aborting...`
+    );
+  }
+
   const assets = await octokit.repos.getAssets({
     owner: "desktop",
     repo: "dugite-native",
     release_id: release.data.id
   });
 
+  if (assets.data.length !== SUCCESSFUL_RELEASE_FILE_COUNT) {
+    throw new Error(
+      `Latest draft release ${tag} has ${
+        assets.data.length
+      } files, expected ${SUCCESSFUL_RELEASE_FILE_COUNT}. Aborting...`
+    );
+  }
+
+  const entries = [];
+
   for (const asset of assets.data) {
     const { name, browser_download_url } = asset;
     if (name.endsWith(".sha256")) {
       const fileName = name.slice(0, -3);
       console.log(`found SHA256 file ${name} for ${fileName}`);
+      const checksum = downloadFile(browser_download_url);
+      entries.push({ fileName, checksum });
     } else {
-      console.log(`skipping: ${name}`);
+      console.log(`skipping file: ${name}`);
     }
   }
+
+  const fileList = entries.map(e => `| ${e.fileName} | ${e.checksum} |`);
+  const fileListText = fileList.join("\n");
+  const draftReleaseNotes = `{details about what's changed since the last release}
+
+| File | SHA256 checksum |
+| --- | --- |
+${fileListText}`;
+
+  console.log(`draft release: ${draftReleaseNotes}`);
 }
 
 run();

--- a/script/generate-release-notes.js
+++ b/script/generate-release-notes.js
@@ -1,0 +1,58 @@
+const octokit = require("@octokit/rest")();
+
+process.on("unhandledRejection", (reason, p) => {
+  console.log("Unhandled Rejection, reason:", reason);
+});
+
+async function run() {
+  if (process.env.GITHUB_ACCESS_TOKEN == null) {
+    throw new Error("No GITHUB_ACCESS_TOKEN environment variable set");
+  }
+
+  octokit.authenticate({
+    type: "token",
+    token: process.env.GITHUB_ACCESS_TOKEN
+  });
+
+  const user = await octokit.users.get();
+  const me = user.data.login;
+
+  console.log(`✅ token found for ${me}...`);
+  const foundScopes = user.headers["x-oauth-scopes"];
+  if (foundScopes.indexOf("public_repo") === -1) {
+    throw new Error(
+      `Found GITHUB_ACCESS_TOKEN does not have required scope 'public_repo' which is required to read draft releases on dugite-native`
+    );
+  }
+
+  console.log(
+    `✅ token has 'public_scope' scope to make changes to releases...`
+  );
+
+  const release = await octokit.repos.getLatestRelease({
+    owner: "desktop",
+    repo: "dugite-native"
+  });
+
+  console.log(`id: ${release.data.id}`);
+  console.log(`tag name: ${release.data.tag_name}`);
+  console.log(`draft: ${release.data.draft}`);
+
+  const assets = await octokit.repos.getAssets({
+    owner: "desktop",
+    repo: "dugite-native",
+    release_id: release.data.id
+  });
+
+  for (const asset of assets.data) {
+    const { name, browser_download_url } = asset;
+    if (name.endsWith(".sha256")) {
+      const fileName = name.slice(0, -3);
+      console.log(`found SHA256 file ${name} for ${fileName}`);
+    } else {
+      console.log(`skipping: ${name}`);
+    }
+  }
+}
+
+run();


### PR DESCRIPTION
This PR is a replacement for the manual process that I was previously doing to generate releases.

New release process:

 - get yourself a personal access token with `public_repo` scope 
 - `git tag {tag name} && git push origin {tag name}`
 - wait for the Travis build to complete generating the release artifacts
 - `npm run generate-release-notes`
 - visit the draft release URL, tweak things, and publish 

✨✨✨ [**Rendered Release Process Notes**](https://github.com/desktop/dugite-native/blob/script-for-updating-draft-release/docs/releases.md)  ✨✨✨