### PR TITLE
strip newline from checksum files when writing to disk

### DIFF
--- a/script/package.sh
+++ b/script/package.sh
@@ -63,8 +63,8 @@ else
   LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
 fi
 
-echo "$GZIP_CHECKSUM" > "${GZIP_FILE}.sha256"
-echo "$LZMA_CHECKSUM" > "${LZMA_FILE}.sha256"
+echo "$GZIP_CHECKSUM" | tr -d '\n' > "${GZIP_FILE}.sha256"
+echo "$LZMA_CHECKSUM" | tr -d '\n' > "${LZMA_FILE}.sha256"
 
 GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
 LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -42,8 +42,11 @@ else
   LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
 fi
 
-GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
-LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+GZIP_SIZE=\$(du -h $GZIP_FILE | cut -f1)
+LZMA_SIZE=\$(du -h $LZMA_FILE | cut -f1)
+
+echo "$\{GZIP_CHECKSUM}" | tr -d '\\n' > "\${GZIP_FILE}.sha256"
+echo "$\{LZMA_CHECKSUM}" | tr -d '\\n' > "\${LZMA_FILE}.sha256"
 
 echo "Packages created:"
 echo "\${GZIP_FILE} - \${GZIP_SIZE} - checksum: \${GZIP_CHECKSUM}"

--- a/test/macos.sh
+++ b/test/macos.sh
@@ -5,9 +5,9 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_VERSION=2.5.1 \
+GIT_LFS_VERSION=2.5.2 \
 TARGET_PLATFORM=macOS \
-GIT_LFS_CHECKSUM=2ade1f42d51b012db0658838d6e1050af7e269d46c84d978bca82d74788e1c2e \
+GIT_LFS_CHECKSUM=eedb80c79f1d3106aa5f1496ddc505e1c1c86c290293d81fb20c5358c615fd74 \
 . "$ROOT/script/build-macos.sh" $SOURCE $DESTINATION
 
 echo "Archive contents:"
@@ -38,6 +38,9 @@ fi
 
 GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
 LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+
+echo "${GZIP_CHECKSUM}" | tr -d '\n' > "${GZIP_FILE}.sha256"
+echo "${LZMA_CHECKSUM}" | tr -d '\n' > "${LZMA_FILE}.sha256"
 
 echo "Packages created:"
 echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"

--- a/test/ubuntu.sh
+++ b/test/ubuntu.sh
@@ -5,9 +5,9 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_VERSION=2.5.1 \
+GIT_LFS_VERSION=2.5.2 \
 TARGET_PLATFORM=ubuntu \
-GIT_LFS_CHECKSUM=9565fa9c2442c3982567a3498c9352cda88e0f6a982648054de0440e273749e7 \
+GIT_LFS_CHECKSUM=624396e8994578ac38c3e5987889be56dba453c378c0675d56cffbc5b8972aa5 \
 . "$ROOT/script/build-ubuntu.sh" $SOURCE $DESTINATION
 
 echo "Archive contents:"
@@ -38,6 +38,9 @@ fi
 
 GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
 LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+
+echo "${GZIP_CHECKSUM}" | tr -d '\n' > "${GZIP_FILE}.sha256"
+echo "${LZMA_CHECKSUM}" | tr -d '\n' > "${LZMA_FILE}.sha256"
 
 echo "Packages created:"
 echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -8,8 +8,8 @@ DESTINATION="$ROOT/build/git"
 GIT_LFS_VERSION=2.5.2 \
 TARGET_PLATFORM=win32 \
 WIN_ARCH=32 \
-GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.19.0.windows.1/MinGit-2.19.0-32-bit.zip \
-GIT_FOR_WINDOWS_CHECKSUM=83cf018bd6f5c24e2b3088539bbeef9067fd632087d094d447a3a0ff676e7bd7 \
+GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip \
+GIT_FOR_WINDOWS_CHECKSUM=9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922 \
 GIT_LFS_CHECKSUM=6cf7d4c169a17dd5b326f903708829e7471368b7e1235ab150ce77555f47b213 \
 . "$ROOT/script/build-win32.sh" $SOURCE $DESTINATION
 

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -5,12 +5,12 @@ ROOT="$DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_VERSION=2.5.1 \
+GIT_LFS_VERSION=2.5.2 \
 TARGET_PLATFORM=win32 \
 WIN_ARCH=32 \
 GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.19.0.windows.1/MinGit-2.19.0-32-bit.zip \
 GIT_FOR_WINDOWS_CHECKSUM=83cf018bd6f5c24e2b3088539bbeef9067fd632087d094d447a3a0ff676e7bd7 \
-GIT_LFS_CHECKSUM=64eb8782df371e5ef3b8cf07134a745be2b782920726ba2b924cc3d56b7c03ed \
+GIT_LFS_CHECKSUM=6cf7d4c169a17dd5b326f903708829e7471368b7e1235ab150ce77555f47b213 \
 . "$ROOT/script/build-win32.sh" $SOURCE $DESTINATION
 
 echo "Archive contents:"
@@ -41,6 +41,9 @@ fi
 
 GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
 LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+
+echo "${GZIP_CHECKSUM}" | tr -d '\n' > "${GZIP_FILE}.sha256"
+echo "${LZMA_CHECKSUM}" | tr -d '\n' > "${LZMA_FILE}.sha256"
 
 echo "Packages created:"
 echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"


### PR DESCRIPTION
When you pipe a string to a file on disk it adds a `\n`, which was added in #111. I worked around this when reading the checksum file by trimming whitespace, but this PR now negates that workaround and ensures the file contents (64 bytes) is just the checksum.

This also updates the test scripts after bumping Git LFS in #112 