### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,172 @@
+variables:
+  GIT_LFS_VERSION: "2.6.0"
+
+resources:
+  repositories:
+    - repository: self
+      checkoutOptions:
+        submodules: true
+
+jobs:
+  - job: Ubuntu
+    displayName: "Ubuntu Linux (AMD64)"
+    pool:
+      vmImage: ubuntu-16.04
+    variables:
+      TARGET_PLATFORM: ubuntu
+      GIT_LFS_CHECKSUM: 43e9311bdded82d43c574b075aafaf56681a3450c1ccf59cce9d362acabf1362
+    steps:
+      - script: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gettext
+        displayName: Install dependencies
+      - script: script/build.sh
+        displayName: Build
+      - script: script/package.sh
+        displayName: Package
+      - task: CopyFiles@2
+        inputs:
+          contents: |
+            output/*.tar.gz
+            output/*.lzma
+            output/*.sha256
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+      - task: PublishBuildArtifacts@1
+
+  - job: Linux_ARM64
+    displayName: "Linux (arm64)"
+    pool:
+      vmImage: "ubuntu-16.04"
+    variables:
+      TARGET_PLATFORM: arm64
+      GIT_LFS_CHECKSUM: 574192d485ce84495fe3f228a57e3ef80f93635ae4677ac4a189425b4c9aeb0a
+    steps:
+      - script: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+        displayName: "Register Docker QEMU"
+      - task: docker@0
+        displayName: "Build Git in container"
+        inputs:
+          action: "Run an image"
+          imageName: shiftkey/dugite-native:arm64-jessie-git
+          volumes: |
+            $(Build.SourcesDirectory):/src
+            $(Build.SourcesDirectory)/build/git:/output
+          envVars: |
+            SOURCE=/src/git
+            DESTINATION=/output
+          workDir: /src
+          containerCommand: "sh /src/script/arm64/build-git.sh"
+          detached: false
+      - bash: script/arm64/bundle-git-lfs.sh
+        displayName: "Bundle Git LFS"
+        env:
+          DESTINATION: $(Build.SourcesDirectory)/build/git
+      - task: docker@0
+        displayName: Verify Git LFS in container
+        inputs:
+          action: "Run an image"
+          imageName: shiftkey/dugite-native:arm64-jessie-git
+          volumes: |
+            $(Build.SourcesDirectory):/src
+            $(Build.SourcesDirectory)/build/git:/output
+          envVars: |
+            DESTINATION=/output
+          workDir: /src
+          containerCommand: "sh /src/script/arm64/verify-git-lfs.sh"
+          detached: false
+      - bash: script/arm64/verify-git.sh
+        displayName: "Verify Git"
+        env:
+          DESTINATION: $(Build.SourcesDirectory)/build/git
+      - bash: script/arm64/package.sh
+        displayName: Package
+        env:
+          SOURCE: $(Build.SourcesDirectory)/git
+          DESTINATION: $(Build.SourcesDirectory)/build/git
+      - task: CopyFiles@2
+        inputs:
+          contents: |
+            output/*.tar.gz
+            output/*.lzma
+            output/*.sha256
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+      - task: PublishBuildArtifacts@1
+
+  - job: macOS
+    pool:
+      vmImage: xcode9-macos10.13
+    variables:
+      TARGET_PLATFORM: macOS
+      GIT_LFS_CHECKSUM: 42bf89b9775a69ab7dbe65847e174fe802d54ce6ed0d553bd497c740f2803f60
+    steps:
+      - bash: script/build.sh
+        displayName: Build
+      - bash: script/package.sh
+        displayName: Package
+      - task: CopyFiles@2
+        inputs:
+          contents: |
+            output/*.tar.gz
+            output/*.lzma
+            output/*.sha256
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+      - task: PublishBuildArtifacts@1
+
+  - job: Windows_64bit
+    displayName: "Windows (64-bit)"
+    pool:
+      vmImage: vs2017-win2016
+    variables:
+      TARGET_PLATFORM: win32
+      WIN_ARCH: 64
+      GIT_LFS_CHECKSUM: f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279
+      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip
+      GIT_FOR_WINDOWS_CHECKSUM: f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3
+    steps:
+      - script: |
+          choco install 7zip
+        displayName: Install dependencies
+      - bash: script/build.sh
+        displayName: Build
+      - bash: script/package.sh
+        displayName: Package
+      - task: CopyFiles@2
+        inputs:
+          contents: |
+            output/*.tar.gz
+            output/*.lzma
+            output/*.sha256
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+      - task: PublishBuildArtifacts@1
+
+  - job: Windows_32bit
+    displayName: "Windows (32-bit)"
+    pool:
+      vmImage: vs2017-win2016
+    variables:
+      TARGET_PLATFORM: win32
+      WIN_ARCH: 32
+      GIT_LFS_CHECKSUM: 7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5
+      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip
+      GIT_FOR_WINDOWS_CHECKSUM: 9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922
+    steps:
+      - script: |
+          choco install 7zip
+        displayName: Install dependencies
+      - bash: script/build.sh
+        displayName: Build
+      - bash: script/package.sh
+        displayName: Package
+      - task: CopyFiles@2
+        inputs:
+          contents: |
+            output/*.tar.gz
+            output/*.lzma
+            output/*.sha256
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+      - task: PublishBuildArtifacts@1

--- a/script/arm64/build-git.sh
+++ b/script/arm64/build-git.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+if [[ -z "${SOURCE}" ]]; then
+  echo "Required environment variable SOURCE was not set"
+  exit 1
+fi
+
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
+
+echo " -- Building git at $SOURCE to $DESTINATION"
+
+cd "$SOURCE"
+make clean
+DESTDIR="$DESTINATION" make strip install prefix=/ \
+    NO_PERL=1 \
+    NO_TCLTK=1 \
+    NO_GETTEXT=1 \
+    NO_INSTALL_HARDLINKS=1 \
+    CC='gcc' \
+    CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
+    LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro'
+
+echo "-- Removing server-side programs"
+rm -f "$DESTINATION/bin/git-cvsserver"
+rm -f "$DESTINATION/bin/git-receive-pack"
+rm -f "$DESTINATION/bin/git-upload-archive"
+rm -f "$DESTINATION/bin/git-upload-pack"
+rm -f "$DESTINATION/bin/git-shell"
+
+echo "-- Removing unsupported features"
+rm -f "$DESTINATION/libexec/git-core/git-svn"
+rm -f "$DESTINATION/libexec/git-core/git-remote-testsvn"
+rm -f "$DESTINATION/libexec/git-core/git-p4"
+
+# because we are building Git in a container, we need to ensure the regular
+# user is able to modify the output outside of this script
+chmod 777 "$DESTINATION/libexec/git-core"
+
+(
+# download CA bundle and write straight to temp folder
+# for more information: https://curl.haxx.se/docs/caextract.html
+echo "-- Adding CA bundle"
+cd "$DESTINATION"
+mkdir -p ssl
+curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
+cd - > /dev/null
+)

--- a/script/arm64/bundle-git-lfs.sh
+++ b/script/arm64/bundle-git-lfs.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=script/compute-checksum.sh
+source "$CURRENT_DIR/../compute-checksum.sh"
+
+if [[ "$GIT_LFS_VERSION" ]]; then
+  echo "-- Bundling Git LFS"
+  GIT_LFS_FILE=git-lfs.tar.gz
+  GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-arm64-v${GIT_LFS_VERSION}.tar.gz"
+  echo "-- Downloading from $GIT_LFS_URL"
+  curl -sL -o $GIT_LFS_FILE "$GIT_LFS_URL"
+  COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)
+  if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
+    echo "Git LFS: checksums match"
+    SUBFOLDER="$DESTINATION/libexec/git-core"
+    tar -xvf $GIT_LFS_FILE -C "$SUBFOLDER" --exclude='*.sh' --exclude="*.md"
+
+    if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
+      echo "After extracting Git LFS the file was not found under libexec/git-core/"
+      echo "aborting..."
+      exit 1
+    fi
+  else
+    echo "Git LFS: expected checksum $GIT_LFS_CHECKSUM but got $COMPUTED_SHA256"
+    echo "aborting..."
+    exit 1
+  fi
+else
+  echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+fi

--- a/script/arm64/package.sh
+++ b/script/arm64/package.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -e
+#
+# Script for packaging artefacts into gzipped archive.
+# Build scripts should handle platform-specific differences, so this
+# script works off the assumption that everything at $DESTINATION is
+# intended to be part of the archive.
+#
+
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
+
+VERSION=$(
+  cd "$SOURCE" || exit 1
+  VERSION=$(git describe --exact-match HEAD)
+  EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" == "128" ]; then
+    echo "Git commit does not have tag, cannot use version to build from"
+    exit 1
+  fi
+  echo "$VERSION"
+)
+
+BUILD_HASH=$(git rev-parse --short HEAD)
+
+if ! [ -d "$DESTINATION" ]; then
+  echo "No output found, exiting..."
+  exit 1
+fi
+
+GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.tar.gz"
+LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.lzma"
+
+(
+echo ""
+echo "Creating archives..."
+mkdir output
+cd output
+if [ "$(uname -s)" == "Darwin" ]; then
+  tar -czf "$GZIP_FILE" -C "$DESTINATION" .
+  tar --lzma -cf "$LZMA_FILE" -C "$DESTINATION" .
+else
+  tar -caf "$GZIP_FILE" -C "$DESTINATION" .
+  tar -caf "$LZMA_FILE" -C "$DESTINATION" .
+fi
+
+GZIP_CHECKSUM=$(shasum -a 256 "$GZIP_FILE" | awk '{print $1;}')
+LZMA_CHECKSUM=$(shasum -a 256 "$LZMA_FILE" | awk '{print $1;}')
+
+echo "$GZIP_CHECKSUM" | tr -d '\n' > "${GZIP_FILE}.sha256"
+echo "$LZMA_CHECKSUM" | tr -d '\n' > "${LZMA_FILE}.sha256"
+
+GZIP_SIZE=$(du -h "$GZIP_FILE" | cut -f1)
+LZMA_SIZE=$(du -h "$LZMA_FILE" | cut -f1)
+
+echo "Packages created:"
+echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"
+echo "${LZMA_FILE} - ${LZMA_SIZE} - checksum: ${LZMA_CHECKSUM}"
+)

--- a/script/arm64/verify-git-lfs.sh
+++ b/script/arm64/verify-git-lfs.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
+
+if [[ "$GIT_LFS_VERSION" ]]; then
+    "$DESTINATION/libexec/git-core/git-lfs" --version
+else
+  echo "-- Skipped verifying Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+fi

--- a/script/arm64/verify-git.sh
+++ b/script/arm64/verify-git.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=script/compute-checksum.sh
+source "$CURRENT_DIR/../check-static-linking.sh"
+
+echo "-- Static linking research"
+check_static_linking "$DESTINATION"


### PR DESCRIPTION
The TravisCI builds have gotten kinda hairy, and so rather than using Docker in Travis I'm going to see if Azure Pipelines' Docker support is more flexible for what I need (and the ability to publish releases from builds on-demand is something I'm also interested in).

 - [x] Hello, world!™
 - [x] Port one main build over
 - [x] Port ARM64 build over
 - [x] Port the rest
 - [x] Experiment with publishing artefacts
 - [ ] add script to generate config and add `npm run generate-pipelines` to `package.json`
 - [x] windows builds now fail correctly because they can't `lzma`
