### PR TITLE
Get LFS only when GIT_LFS_VERSION is set and warn if not

### DIFF
--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -54,6 +54,10 @@ mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
 cd - > /dev/null
 
+if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
+  echo "-- Skipped bundling of CA certificates (failed to download them)"
+fi
+
 
 checkStaticLinking() {
   if [ -z "$1" ] ; then
@@ -82,10 +86,6 @@ do
 done
 cd - > /dev/null
 
-
-if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
-  echo "warning: Skipped bundling of CA certificates (failed to download them)"
-fi
 
 if [[ ! "$GIT_LFS_VERSION" ]]; then
   echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -86,6 +86,10 @@ cd - > /dev/null
 bold=$(tput bold)
 normal=$(tput sgr0)
 
+if [[ ! -f "ssl/cacert.pem" ]]; then
+  echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
+fi
+
 if [[ ! "$GIT_LFS_VERSION" ]]; then
   echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -86,7 +86,7 @@ cd - > /dev/null
 bold=$(tput bold)
 normal=$(tput sgr0)
 
-if [[ ! -f "ssl/cacert.pem" ]]; then
+if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
   echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
 fi
 

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -85,8 +85,3 @@ do
   checkStaticLinking $file
 done
 cd - > /dev/null
-
-
-if [[ ! "$GIT_LFS_VERSION" ]]; then
-  echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
-fi

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -81,3 +81,11 @@ do
   checkStaticLinking $file
 done
 cd - > /dev/null
+
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+if [[ ! "$GIT_LFS_VERSION" ]]; then
+  echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+fi

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -83,13 +83,10 @@ done
 cd - > /dev/null
 
 
-bold=$(tput bold)
-normal=$(tput sgr0)
-
 if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
-  echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
+  echo "warning: Skipped bundling of CA certificates (failed to download them)"
 fi
 
 if [[ ! "$GIT_LFS_VERSION" ]]; then
-  echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+  echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -42,7 +42,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   SUBFOLDER="$DESTINATION/libexec/git-core"
   cp $GIT_LFS_FILE $SUBFOLDER
 else
-  echo "-- Skipping Git LFS"
+  echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi
 
 

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -80,7 +80,7 @@ rm "$DESTINATION/libexec/git-core/git-p4"
 bold=$(tput bold)
 normal=$(tput sgr0)
 
-if [[ ! -f "ssl/cacert.pem" ]]; then
+if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
   echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
 fi
 

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -75,8 +75,3 @@ echo "-- Removing unsupported features"
 rm "$DESTINATION/libexec/git-core/git-svn"
 rm "$DESTINATION/libexec/git-core/git-remote-testsvn"
 rm "$DESTINATION/libexec/git-core/git-p4"
-
-
-if [[ ! "$GIT_LFS_VERSION" ]]; then
-  echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
-fi

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -75,3 +75,11 @@ echo "-- Removing unsupported features"
 rm "$DESTINATION/libexec/git-core/git-svn"
 rm "$DESTINATION/libexec/git-core/git-remote-testsvn"
 rm "$DESTINATION/libexec/git-core/git-p4"
+
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+if [[ ! "$GIT_LFS_VERSION" ]]; then
+  echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+fi

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -35,28 +35,34 @@ DESTDIR="$DESTINATION" make strip install prefix=/ \
     MACOSX_DEPLOYMENT_TARGET=10.9
 cd - > /dev/null
 
-echo "-- Bundling Git LFS"
-GIT_LFS_FILE=git-lfs.tar.gz
-GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-darwin-amd64-v${GIT_LFS_VERSION}.tar.gz"
-echo "-- Downloading from $GIT_LFS_URL"
-curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
-COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
-if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
-  echo "Git LFS: checksums match"
-  SUBFOLDER="$DESTINATION/libexec/git-core"
-  # strip out any text files when extracting the Git LFS archive
-  tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude='*.md'
 
-  if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
-    echo "After extracting Git LFS the file was not found under libexec/git-core/"
+if [[ "$GIT_LFS_VERSION" ]]; then
+  echo "-- Bundling Git LFS"
+  GIT_LFS_FILE=git-lfs.tar.gz
+  GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-darwin-amd64-v${GIT_LFS_VERSION}.tar.gz"
+  echo "-- Downloading from $GIT_LFS_URL"
+  curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
+  COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
+  if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
+    echo "Git LFS: checksums match"
+    SUBFOLDER="$DESTINATION/libexec/git-core"
+    # strip out any text files when extracting the Git LFS archive
+    tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude='*.md'
+
+    if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
+      echo "After extracting Git LFS the file was not found under libexec/git-core/"
+      echo "aborting..."
+      exit 1
+    fi
+  else
+    echo "Git LFS: expected checksum $GIT_LFS_CHECKSUM but got $COMPUTED_SHA256"
     echo "aborting..."
     exit 1
   fi
 else
-  echo "Git LFS: expected checksum $GIT_LFS_CHECKSUM but got $COMPUTED_SHA256"
-  echo "aborting..."
-  exit 1
+  echo "-- Skipping Git LFS"
 fi
+
 
 echo "-- Removing server-side programs"
 rm "$DESTINATION/bin/git-cvsserver"

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -60,7 +60,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
     exit 1
   fi
 else
-  echo "-- Skipping Git LFS"
+  echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi
 
 

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -77,13 +77,10 @@ rm "$DESTINATION/libexec/git-core/git-remote-testsvn"
 rm "$DESTINATION/libexec/git-core/git-p4"
 
 
-bold=$(tput bold)
-normal=$(tput sgr0)
-
 if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
-  echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
+  echo "warning: Skipped bundling of CA certificates (failed to download them)"
 fi
 
 if [[ ! "$GIT_LFS_VERSION" ]]; then
-  echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+  echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -77,10 +77,6 @@ rm "$DESTINATION/libexec/git-core/git-remote-testsvn"
 rm "$DESTINATION/libexec/git-core/git-p4"
 
 
-if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
-  echo "warning: Skipped bundling of CA certificates (failed to download them)"
-fi
-
 if [[ ! "$GIT_LFS_VERSION" ]]; then
   echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -80,6 +80,10 @@ rm "$DESTINATION/libexec/git-core/git-p4"
 bold=$(tput bold)
 normal=$(tput sgr0)
 
+if [[ ! -f "ssl/cacert.pem" ]]; then
+  echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
+fi
+
 if [[ ! "$GIT_LFS_VERSION" ]]; then
   echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -117,6 +117,10 @@ cd - > /dev/null
 bold=$(tput bold)
 normal=$(tput sgr0)
 
+if [[ ! -f "ssl/cacert.pem" ]]; then
+  echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
+fi
+
 if [[ ! "$GIT_LFS_VERSION" ]]; then
   echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -114,13 +114,10 @@ done
 cd - > /dev/null
 
 
-bold=$(tput bold)
-normal=$(tput sgr0)
-
 if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
-  echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
+  echo "warning: Skipped bundling of CA certificates (failed to download them)"
 fi
 
 if [[ ! "$GIT_LFS_VERSION" ]]; then
-  echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+  echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -72,6 +72,10 @@ mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
 cd - > /dev/null
 
+if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
+  echo "-- Skipped bundling of CA certificates (failed to download them)"
+fi
+
 
 echo "-- Removing server-side programs"
 rm "$DESTINATION/bin/git-cvsserver"
@@ -113,10 +117,6 @@ do
 done
 cd - > /dev/null
 
-
-if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
-  echo "warning: Skipped bundling of CA certificates (failed to download them)"
-fi
 
 if [[ ! "$GIT_LFS_VERSION" ]]; then
   echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -117,7 +117,7 @@ cd - > /dev/null
 bold=$(tput bold)
 normal=$(tput sgr0)
 
-if [[ ! -f "ssl/cacert.pem" ]]; then
+if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
   echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
 fi
 

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -60,7 +60,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
     exit 1
   fi
 else
-  echo "-- Skipping Git LFS"
+  echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi
 
 

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -116,8 +116,3 @@ do
   checkStaticLinking $file
 done
 cd - > /dev/null
-
-
-if [[ ! "$GIT_LFS_VERSION" ]]; then
-  echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
-fi

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -112,3 +112,11 @@ do
   checkStaticLinking $file
 done
 cd - > /dev/null
+
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+if [[ ! "$GIT_LFS_VERSION" ]]; then
+  echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+fi

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -63,7 +63,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
     exit 1
   fi
 else
-  echo "-- Skipping Git LFS"
+  echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi
 
 

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -101,7 +101,7 @@ echo "-- Removing legacy credential helpers"
 bold=$(tput bold)
 normal=$(tput sgr0)
 
-if [[ ! -f "ssl/cacert.pem" ]]; then
+if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
   echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
 fi
 

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -96,3 +96,11 @@ echo "-- Removing global gitattributes which handles certain file extensions"
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-store.exe"
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-wincred.exe"
 echo "-- Removing legacy credential helpers"
+
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+if [[ ! "$GIT_LFS_VERSION" ]]; then
+  echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+fi

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -98,10 +98,6 @@ rm "$DESTINATION/$MINGW_DIR/bin/git-credential-wincred.exe"
 echo "-- Removing legacy credential helpers"
 
 
-if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
-  echo "warning: Skipped bundling of CA certificates (failed to download them)"
-fi
-
 if [[ ! "$GIT_LFS_VERSION" ]]; then
   echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -98,13 +98,10 @@ rm "$DESTINATION/$MINGW_DIR/bin/git-credential-wincred.exe"
 echo "-- Removing legacy credential helpers"
 
 
-bold=$(tput bold)
-normal=$(tput sgr0)
-
 if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
-  echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
+  echo "warning: Skipped bundling of CA certificates (failed to download them)"
 fi
 
 if [[ ! "$GIT_LFS_VERSION" ]]; then
-  echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+  echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -96,8 +96,3 @@ echo "-- Removing global gitattributes which handles certain file extensions"
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-store.exe"
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-wincred.exe"
 echo "-- Removing legacy credential helpers"
-
-
-if [[ ! "$GIT_LFS_VERSION" ]]; then
-  echo "warning: Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
-fi

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -101,6 +101,10 @@ echo "-- Removing legacy credential helpers"
 bold=$(tput bold)
 normal=$(tput sgr0)
 
+if [[ ! -f "ssl/cacert.pem" ]]; then
+  echo "${bold}warning:${normal} Skipped bundling of CA certificates (failed to download them)"
+fi
+
 if [[ ! "$GIT_LFS_VERSION" ]]; then
   echo "${bold}warning:${normal} Skipped bundling of Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -37,29 +37,35 @@ else
   exit 1
 fi
 
-# download Git LFS, verify its the right contents, and unpack it
-echo "-- Bundling Git LFS"
-GIT_LFS_FILE=git-lfs.zip
-if [ "$WIN_ARCH" -eq "64" ]; then GIT_LFS_ARCH="amd64"; else GIT_LFS_ARCH="386"; fi
-GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-windows-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.zip"
-echo "-- Downloading from $GIT_LFS_URL"
-curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
-COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
-if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
-  echo "Git LFS: checksums match"
-  SUBFOLDER="$DESTINATION/$MINGW_DIR/libexec/git-core"
-  unzip -j $GIT_LFS_FILE -x '*.md' -d $SUBFOLDER
 
-  if [[ ! -f "$SUBFOLDER/git-lfs.exe" ]]; then
-    echo "After extracting Git LFS the file was not found under /mingw64/libexec/git-core/"
+if [[ "$GIT_LFS_VERSION" ]]; then
+  # download Git LFS, verify its the right contents, and unpack it
+  echo "-- Bundling Git LFS"
+  GIT_LFS_FILE=git-lfs.zip
+  if [ "$WIN_ARCH" -eq "64" ]; then GIT_LFS_ARCH="amd64"; else GIT_LFS_ARCH="386"; fi
+  GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-windows-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.zip"
+  echo "-- Downloading from $GIT_LFS_URL"
+  curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
+  COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
+  if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
+    echo "Git LFS: checksums match"
+    SUBFOLDER="$DESTINATION/$MINGW_DIR/libexec/git-core"
+    unzip -j $GIT_LFS_FILE -x '*.md' -d $SUBFOLDER
+
+    if [[ ! -f "$SUBFOLDER/git-lfs.exe" ]]; then
+      echo "After extracting Git LFS the file was not found under /mingw64/libexec/git-core/"
+      echo "aborting..."
+      exit 1
+    fi
+  else
+    echo "Git LFS: expected checksum $GIT_LFS_CHECKSUM and got $COMPUTED_SHA256"
     echo "aborting..."
     exit 1
   fi
 else
-  echo "Git LFS: expected checksum $GIT_LFS_CHECKSUM and got $COMPUTED_SHA256"
-  echo "aborting..."
-  exit 1
+  echo "-- Skipping Git LFS"
 fi
+
 
 SYSTEM_CONFIG="$DESTINATION/$MINGW_DIR/etc/gitconfig"
 


### PR DESCRIPTION
I tried to move the warnings at the end of each `build-*.sh` to a separate shared script, but couldn't make it work due to the relative paths used. I also tried to move that logic to the end of `build.sh` but that part doesn't get executed for some reason. Help welcome there.