### PR TITLE
introduce docker image to speed up ARM64 builds

### DIFF
--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -1,0 +1,11 @@
+# currently tagged on Docker Hub as shiftkey/dugite-native:arm64-jessie-git
+FROM multiarch/debian-debootstrap:arm64-jessie
+
+RUN apt-get update
+RUN apt-get install -y \
+    build-essential \
+    libexpat-dev \
+    curl \
+    libcurl4-openssl-dev \
+    zlib1g-dev \
+    libssl-dev \

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -1,6 +1,4 @@
 echo " -- Building git at $SOURCE to $DESTINATION"
-apt-get update
-apt-get install -y build-essential libexpat-dev libcurl4-openssl-dev zlib1g-dev libssl-dev
 
 cd $SOURCE
 make clean

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -16,7 +16,7 @@ docker run -it \
 -e "SOURCE=$SOURCE" \
 -e "DESTINATION=$DESTINATION" \
 -w=$BASEDIR \
---rm multiarch/debian-debootstrap:arm64-jessie sh $BASEDIR/script/build-arm64-git.sh
+--rm shiftkey/dugite-native:arm64-jessie-git sh $BASEDIR/script/build-arm64-git.sh
 cd - > /dev/null
 
 echo "-- Building Git LFS"
@@ -33,7 +33,7 @@ echo "-- Verifying built Git LFS"
 docker run -it \
  --mount type=bind,source=$GIT_LFS_OUTPUT_DIR,target=$GIT_LFS_OUTPUT_DIR \
  -w=$BASEDIR \
- --rm multiarch/debian-debootstrap:arm64-jessie $GIT_LFS_OUTPUT_DIR/git-lfs --version
+ --rm shiftkey/dugite-native:arm64-jessie-git $GIT_LFS_OUTPUT_DIR/git-lfs --version
 
 echo "-- Bundling Git LFS"
 GIT_LFS_FILE=$GIT_LFS_OUTPUT_DIR/git-lfs


### PR DESCRIPTION
This shaves ~3mins from the ARM64 build (24mins -> 21mins) - not a huge win, but a win nonetheless.