### PR TITLE
add source SHA to build artifacts

### DIFF
--- a/script/package.sh
+++ b/script/package.sh
@@ -20,24 +20,26 @@ if [ "$EXIT_CODE" == "128" ]; then
 fi
 cd - > /dev/null
 
+BUILD_HASH=$(git rev-parse --short HEAD)
+
 if ! [ -d "$DESTINATION" ]; then
   echo "No output found, exiting..."
   exit 1
 fi
 
 if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
-  GZIP_FILE="dugite-native-$VERSION-ubuntu.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-ubuntu.lzma"
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.lzma"
 elif [ "$TARGET_PLATFORM" == "macOS" ]; then
-  GZIP_FILE="dugite-native-$VERSION-macOS.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-macOS.lzma"
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.lzma"
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
   if [ "$WIN_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="x86"; fi
-  GZIP_FILE="dugite-native-$VERSION-windows-$ARCH.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-windows-$ARCH.lzma"
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.lzma"
 elif [ "$TARGET_PLATFORM" == "arm64" ]; then
-  GZIP_FILE="dugite-native-$VERSION-arm64.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-arm64.lzma"
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.lzma"
 else
   echo "Unable to package Git for platform $TARGET_PLATFORM"
   exit 1


### PR DESCRIPTION
We follow Git's numeric versioning here (e.g. `2.19.1`) and add an extra number to the Git tag (e.g. `2.19.1-2`) to indicate further updates, but we don't use the tag in the file name. I want to avoid our tagged version being interpreted as Git's version, but this has lead to some confusion with file caching (`dugite` handles it fine, but end users see some "cached version invalid" messages that actually meant it was looking at the old version).

This PR embeds the abbreviated commit ID of `dugite-native` into the filename to help with traceability and cache-busting.
