### PR TITLE
linux/arm64: build a vanilla libcurl and link to that

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ matrix:
       env:
         - TARGET_PLATFORM=ubuntu
         - GIT_LFS_CHECKSUM=624396e8994578ac38c3e5987889be56dba453c378c0675d56cffbc5b8972aa5
-      addons:
-        apt:
-          packages:
-            - libcurl4-openssl-dev
 
     - os: osx
       language: c

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -1,4 +1,4 @@
-# currently tagged on Docker Hub as shiftkey/dugite-native:arm64-jessie-git
+# currently tagged on Docker Hub as shiftkey/dugite-native:arm64-jessie-git-with-curl
 FROM multiarch/debian-debootstrap:arm64-jessie
 
 RUN apt-get update
@@ -7,6 +7,24 @@ RUN apt-get install -y \
     autoconf \
     libexpat-dev \
     curl \
-    libcurl4-openssl-dev \
     zlib1g-dev \
-    libssl-dev \
+    libssl-dev
+
+ENV CURL_INSTALL_DIR "/tmp/build/curl"
+ENV CURL_VERSION "curl-7.61.1"
+
+# extract curl to temp directory
+RUN mkdir -p $CURL_INSTALL_DIR
+WORKDIR /tmp
+RUN curl -LO "https://curl.haxx.se/download/$CURL_VERSION.tar.gz"
+RUN tar -xf "$CURL_VERSION.tar.gz"
+
+# configure and install curl
+WORKDIR $CURL_VERSION
+RUN ./configure --prefix=$CURL_INSTALL_DIR
+RUN make install
+
+#cleanup
+WORKDIR /tmp
+RUN rm -rf "$CURL_VERSION.tar.gz"
+RUN rm -rf "$CURL_VERSION"

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get install -y \
     libexpat-dev \
     curl \
     zlib1g-dev \
-    libssl-dev
+    libssl-dev \
+    gettext
 
 ENV CURL_INSTALL_DIR "/tmp/build/curl"
 ENV CURL_VERSION "curl-7.61.1"

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -7,6 +7,7 @@ CC='gcc' \
   CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
   LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro' \
   ./configure \
+  --with-curl=$CURL_INSTALL_DIR \
   --prefix=/
 
 DESTDIR="$DESTINATION" \
@@ -14,6 +15,7 @@ DESTDIR="$DESTINATION" \
     NO_TCLTK=1 \
     NO_GETTEXT=1 \
     NO_INSTALL_HARDLINKS=1 \
+    NO_R_TO_GCC_LINKER=1 \
     make strip install
 
 echo "-- Removing server-side programs"

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -5,7 +5,8 @@
 
 SOURCE=$1
 DESTINATION=$2
-BASEDIR=$3
+CURL_INSTALL_DIR=$3
+BASEDIR=$4
 
 mkdir -p $DESTINATION
 
@@ -15,8 +16,9 @@ docker run -it \
 --mount type=bind,source=$DESTINATION,target=$DESTINATION \
 -e "SOURCE=$SOURCE" \
 -e "DESTINATION=$DESTINATION" \
+-e "CURL_INSTALL_DIR=$CURL_INSTALL_DIR" \
 -w=$BASEDIR \
---rm shiftkey/dugite-native:arm64-jessie-git sh $BASEDIR/script/build-arm64-git.sh
+--rm shiftkey/dugite-native:arm64-jessie-git-with-curl sh $BASEDIR/script/build-arm64-git.sh
 cd - > /dev/null
 
 if [[ "$GIT_LFS_VERSION" ]]; then

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -32,12 +32,6 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   make GOARCH=arm64 GOOS=linux
   GIT_LFS_OUTPUT_DIR=$GOPATH/src/github.com/git-lfs/git-lfs/bin/
 
-  echo "-- Verifying built Git LFS"
-  docker run -it \
-    --mount type=bind,source=$GIT_LFS_OUTPUT_DIR,target=$GIT_LFS_OUTPUT_DIR \
-    -w=$BASEDIR \
-    --rm shiftkey/dugite-native:arm64-jessie-git $GIT_LFS_OUTPUT_DIR/git-lfs --version
-
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=$GIT_LFS_OUTPUT_DIR/git-lfs
   SUBFOLDER="$DESTINATION/libexec/git-core"
@@ -58,6 +52,13 @@ if [[ ! -f "$DESTINATION/ssl/cacert.pem" ]]; then
   echo "-- Skipped bundling of CA certificates (failed to download them)"
 fi
 
+echo "-- Verifying environment"
+docker run -it \
+  --mount type=bind,source=$BASEDIR,target=$BASEDIR \
+  --mount type=bind,source=$DESTINATION,target=$DESTINATION \
+  -e "DESTINATION=$DESTINATION" \
+  -w=$BASEDIR \
+  --rm shiftkey/dugite-native:arm64-jessie-git-with-curl sh $BASEDIR/script/verify-arm64-git.sh
 
 checkStaticLinking() {
   if [ -z "$1" ] ; then

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -143,3 +143,20 @@ do
   checkStaticLinking $file
 done
 cd - > /dev/null
+
+echo "-- Testing clone operation with generated binary"
+
+rm -rf $CURL_OUTPUT_DIR
+
+TEMP_CLONE_DIR=/tmp/clones
+mkdir -p $TEMP_CLONE_DIR
+
+cd "$DESTINATION/bin"
+./git --version
+GIT_CURL_VERBOSE=1 \
+  GIT_TEMPLATE_DIR="$DESTINATION/share/git-core/templates" \
+  GIT_SSL_CAINFO="$DESTINATION/ssl/cacert.pem" \
+  GIT_EXEC_PATH="$DESTINATION/libexec/git-core" \
+  PREFIX="$DESTINATION" \
+  ./git clone https://github.com/git/git.github.io "$TEMP_CLONE_DIR/git.github.io"
+cd - > /dev/null

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -5,6 +5,7 @@
 
 SOURCE=$1
 DESTINATION=$2
+CURL_INSTALL_DIR=$3
 
 # i want to centralize this function but everything is terrible
 # go read https://github.com/desktop/dugite-native/issues/38
@@ -21,6 +22,19 @@ computeChecksum() {
     echo $(shasum -a 256 $1 | awk '{print $1;}')
   fi
 }
+
+echo " -- Building vanilla curl at $CURL_INSTALL_DIR instead of distro-specific version"
+
+CURL_FILE_NAME="curl-7.61.1"
+CURL_FILE="$CURL_FILE_NAME.tar.gz"
+
+cd /tmp
+curl -LO "https://curl.haxx.se/download/$CURL_FILE"
+tar -xf $CURL_FILE
+cd $CURL_FILE_NAME
+./configure --prefix=$CURL_INSTALL_DIR
+make install
+cd - > /dev/null
 
 echo " -- Building git at $SOURCE to $DESTINATION"
 

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -45,11 +45,13 @@ CC='gcc' \
   CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
   LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro' \
   ./configure \
+  --with-curl=$CURL_INSTALL_DIR \
   --prefix=/
 DESTDIR="$DESTINATION" \
   NO_TCLTK=1 \
   NO_GETTEXT=1 \
   NO_INSTALL_HARDLINKS=1 \
+  NO_R_TO_GCC_LINKER=1 \
   make strip install
 cd - > /dev/null
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -17,7 +17,7 @@ elif [ "$TARGET_PLATFORM" == "macOS" ]; then
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
   bash "$DIR/build-win32.sh" $DESTINATION
 elif [ "$TARGET_PLATFORM" == "arm64" ]; then
-  bash "$DIR/build-arm64.sh" $SOURCE $DESTINATION $BASEDIR
+  bash "$DIR/build-arm64.sh" $SOURCE $DESTINATION $CURL_INSTALL_DIR $BASEDIR
 else
   echo "Unable to build Git for platform $TARGET_PLATFORM"
   exit 1

--- a/script/build.sh
+++ b/script/build.sh
@@ -8,9 +8,10 @@ BASEDIR=`pwd`
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE="${BASEDIR}/git"
 DESTINATION="/tmp/build/git"
+CURL_INSTALL_DIR="/tmp/build/curl"
 
 if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
-  bash "$DIR/build-ubuntu.sh" $SOURCE $DESTINATION
+  bash "$DIR/build-ubuntu.sh" $SOURCE $DESTINATION $CURL_INSTALL_DIR
 elif [ "$TARGET_PLATFORM" == "macOS" ]; then
   bash "$DIR/build-macos.sh" $SOURCE $DESTINATION
 elif [ "$TARGET_PLATFORM" == "win32" ]; then

--- a/script/verify-arm64-git.sh
+++ b/script/verify-arm64-git.sh
@@ -1,0 +1,18 @@
+echo "-- Test compiled Git LFS"
+
+$DESTINATION/libexec/git-core/git-lfs --version
+
+echo "-- Test clone operation with generated binary"
+
+TEMP_CLONE_DIR=/tmp/clones
+mkdir -p $TEMP_CLONE_DIR
+
+cd "$DESTINATION/bin"
+./git --version
+GIT_CURL_VERBOSE=1 \
+  GIT_TEMPLATE_DIR="$DESTINATION/share/git-core/templates" \
+  GIT_SSL_CAINFO="$DESTINATION/ssl/cacert.pem" \
+  GIT_EXEC_PATH="$DESTINATION/libexec/git-core" \
+  PREFIX="$DESTINATION" \
+  ./git clone https://github.com/git/git.github.io "$TEMP_CLONE_DIR/git.github.io"
+cd - > /dev/null


### PR DESCRIPTION
A first pass at resolving #109 by linking to `CURL_OPENSSL_4` and `libcurl.so.4` rather than our current situation of `CURL_OPENSSL_3` and `libcurl.so.4`.

 - Linux build
   - [x] update config to build against plain `libcurl`
   - [x] add test to verify clone works with generated binary and downloaded CA bundle
   - [x] cleanup distro-specific curl development packages 
 - ARM64 build
   - [x] update config to build against plain `libcurl`
   - [x] add test to verify clone works with generated binary and downloaded CA bundle
   - [x] cleanup distro-specific curl development packages
