### PR TITLE
linux: apply the flags in the right spots

### DIFF
--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -26,14 +26,17 @@ echo " -- Building git at $SOURCE to $DESTINATION"
 
 cd $SOURCE
 make clean
-DESTDIR="$DESTINATION" make strip install prefix=/ \
-    NO_PERL=1 \
-    NO_TCLTK=1 \
-    NO_GETTEXT=1 \
-    NO_INSTALL_HARDLINKS=1 \
-    CC='gcc' \
-    CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
-    LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro'
+make configure
+CC='gcc' \
+  CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
+  LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro' \
+  ./configure \
+  --prefix=/
+DESTDIR="$DESTINATION" \
+  NO_TCLTK=1 \
+  NO_GETTEXT=1 \
+  NO_INSTALL_HARDLINKS=1 \
+  make strip install
 cd - > /dev/null
 
 


### PR DESCRIPTION
Not sure how I ended up like this, but environment variables _after_ the `make` command are probably not being applied. This PR tries to get these in the right order.