### PR TITLE
linux/arm: look at the destination for the downloaded bundle

### DIFF
--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -52,7 +52,7 @@ mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
 cd - > /dev/null
 
-if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
+if [[ ! -f "$DESTINATION/ssl/cacert.pem" ]]; then
   echo "-- Skipped bundling of CA certificates (failed to download them)"
 fi
 

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -75,7 +75,7 @@ mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
 cd - > /dev/null
 
-if [[ ! -f "$SOURCE/ssl/cacert.pem" ]]; then
+if [[ ! -f "$DESTINATION/ssl/cacert.pem" ]]; then
   echo "-- Skipped bundling of CA certificates (failed to download them)"
 fi
 


### PR DESCRIPTION
I overlooked this in #123 but this step should look at the output directory for the downloaded certificate bundle