### PR TITLE
linux/arm64: reorder git build steps to ensure environment variables are set

### DIFF
--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -4,6 +4,7 @@ FROM multiarch/debian-debootstrap:arm64-jessie
 RUN apt-get update
 RUN apt-get install -y \
     build-essential \
+    autoconf \
     libexpat-dev \
     curl \
     libcurl4-openssl-dev \

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -2,14 +2,19 @@ echo " -- Building git at $SOURCE to $DESTINATION"
 
 cd $SOURCE
 make clean
-DESTDIR="$DESTINATION" make strip install prefix=/ \
+make configure
+CC='gcc' \
+  CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
+  LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro' \
+  ./configure \
+  --prefix=/
+
+DESTDIR="$DESTINATION" \
     NO_PERL=1 \
     NO_TCLTK=1 \
     NO_GETTEXT=1 \
     NO_INSTALL_HARDLINKS=1 \
-    CC='gcc' \
-    CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
-    LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro'
+    make strip install
 
 echo "-- Removing server-side programs"
 rm "$DESTINATION/bin/git-cvsserver"


### PR DESCRIPTION
- [x] confirm Linux build looks fine
- [x] add autoconf to ARM64 container
- [ ] confirm ARM64 build looks fine