### PR TITLE
add shellcheck verification to keep scripts under control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,11 @@ matrix:
         - TARGET_PLATFORM=arm64
         - GIT_LFS_CHECKSUM=574192d485ce84495fe3f228a57e3ef80f93635ae4677ac4a189425b4c9aeb0a
 
+    - os: linux
+      language: shell
+      script:
+        - bash -c 'shopt -s globstar; shellcheck script/**/*.sh'
+
 compiler:
   - gcc
 

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -1,3 +1,12 @@
+#!/bin/bash
+#
+# Compiling Git for ARM64 Linux (should be run inside a container)
+#
+# Required environment variables:
+# - SOURCE
+# - DESTINATION
+# - CURL_INSTALL_DIR
+
 echo " -- Building git at $SOURCE to $DESTINATION"
 
 cd "$SOURCE" || exit 1

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -1,13 +1,13 @@
 echo " -- Building git at $SOURCE to $DESTINATION"
 
-cd $SOURCE
+cd "$SOURCE" || exit 1
 make clean
 make configure
 CC='gcc' \
   CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
   LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro' \
   ./configure \
-  --with-curl=$CURL_INSTALL_DIR \
+  --with-curl="$CURL_INSTALL_DIR" \
   --prefix=/
 
 DESTDIR="$DESTINATION" \

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -9,7 +9,9 @@ CURL_INSTALL_DIR=$3
 BASEDIR=$4
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=script/compute-checksum.sh
 source "$CURRENT_DIR/compute-checksum.sh"
+# shellcheck source=script/check-static-linking.sh
 source "$CURRENT_DIR/check-static-linking.sh"
 
 mkdir -p "$DESTINATION"

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -11,11 +11,13 @@ computeChecksum() {
      exit 1
    fi
 
-  path_to_sha256sum=$(which sha256sum)
+  FILE=$1
+
+  path_to_sha256sum=$(command -v sha256sum)
   if [ -x "$path_to_sha256sum" ] ; then
-    echo $(sha256sum $1 | awk '{print $1;}')
+    sha256sum "$FILE" | awk '{print $1;}'
   else
-    echo $(shasum -a 256 $1 | awk '{print $1;}')
+    shasum -a 256 "$FILE" | awk '{print $1;}'
   fi
 }
 
@@ -24,18 +26,17 @@ DESTINATION=$2
 CURL_INSTALL_DIR=$3
 BASEDIR=$4
 
-mkdir -p $DESTINATION
+mkdir -p "$DESTINATION"
 
 docker run --rm --privileged multiarch/qemu-user-static:register --reset
 docker run -it \
---mount type=bind,source=$BASEDIR,target=$BASEDIR \
---mount type=bind,source=$DESTINATION,target=$DESTINATION \
+--mount type=bind,source="$BASEDIR",target="$BASEDIR" \
+--mount type=bind,source="$DESTINATION",target="$DESTINATION" \
 -e "SOURCE=$SOURCE" \
 -e "DESTINATION=$DESTINATION" \
 -e "CURL_INSTALL_DIR=$CURL_INSTALL_DIR" \
--w=$BASEDIR \
---rm shiftkey/dugite-native:arm64-jessie-git-with-curl sh $BASEDIR/script/build-arm64-git.sh
-cd - > /dev/null
+-w="$BASEDIR" \
+--rm shiftkey/dugite-native:arm64-jessie-git-with-curl sh "$BASEDIR/script/build-arm64-git.sh"
 
 
 if [[ "$GIT_LFS_VERSION" ]]; then
@@ -43,12 +44,12 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   GIT_LFS_FILE=git-lfs.tar.gz
   GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-arm64-v${GIT_LFS_VERSION}.tar.gz"
   echo "-- Downloading from $GIT_LFS_URL"
-  curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
+  curl -sL -o $GIT_LFS_FILE "$GIT_LFS_URL"
   COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/libexec/git-core"
-    tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude="*.md"
+    tar -xvf $GIT_LFS_FILE -C "$SUBFOLDER" --exclude='*.sh' --exclude="*.md"
 
     if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
       echo "After extracting Git LFS the file was not found under libexec/git-core/"
@@ -65,13 +66,14 @@ else
 fi
 
 
+(
 # download CA bundle and write straight to temp folder
 # for more information: https://curl.haxx.se/docs/caextract.html
 echo "-- Adding CA bundle"
-cd $DESTINATION
+cd "$DESTINATION" || exit 1
 mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
-cd - > /dev/null
+)
 
 if [[ ! -f "$DESTINATION/ssl/cacert.pem" ]]; then
   echo "-- Skipped bundling of CA certificates (failed to download them)"
@@ -79,11 +81,11 @@ fi
 
 echo "-- Verifying environment"
 docker run -it \
-  --mount type=bind,source=$BASEDIR,target=$BASEDIR \
-  --mount type=bind,source=$DESTINATION,target=$DESTINATION \
+  --mount type=bind,source="$BASEDIR",target="$BASEDIR" \
+  --mount type=bind,source="$DESTINATION",target="$DESTINATION" \
   -e "DESTINATION=$DESTINATION" \
-  -w=$BASEDIR \
-  --rm shiftkey/dugite-native:arm64-jessie-git-with-curl sh $BASEDIR/script/verify-arm64-git.sh
+  -w="$BASEDIR" \
+  --rm shiftkey/dugite-native:arm64-jessie-git-with-curl sh "$BASEDIR/script/verify-arm64-git.sh"
 
 checkStaticLinking() {
   if [ -z "$1" ] ; then
@@ -93,29 +95,30 @@ checkStaticLinking() {
 
   # ermagherd there's two whitespace characters between 'LSB' and 'executable'
   # when running this on Travis - why is everything so terrible?
-  if file $1 | grep -q 'ELF 64-bit LSB'; then
-    if readelf -d $1 | grep -q 'Shared library'; then
+  if file "$1" | grep -q 'ELF 64-bit LSB'; then
+    if readelf -d "$1" | grep -q 'Shared library'; then
       echo "File: $file"
       # this is done twice rather than storing in a bash variable because
       # it's easier than trying to preserve the line endings
       echo "readelf output:"
-      readelf -d $1 | grep 'Shared library'
+      readelf -d "$1" | grep 'Shared library'
       # get a list of glibc versions required by the binary
       echo "objdump GLIBC output:"
-      objdump -T $1 | grep -oEi 'GLIBC_[0-9]*.[0-9]*.[0-9]*'| sort | uniq
+      objdump -T "$1" | grep -oEi 'GLIBC_[0-9]*.[0-9]*.[0-9]*'| sort | uniq
       # confirm what version of curl is expected
       echo "objdump curl output:"
-      objdump -T $1 | grep -oEi " curl.*" | sort | uniq
+      objdump -T "$1" | grep -oEi " curl.*" | sort | uniq
       echo ""
     fi
   fi
 }
 
 echo "-- Static linking research"
-cd "$DESTINATION"
+(
+cd "$DESTINATION" || exit 1
 # check all files for ELF exectuables
-find . -type f -print0 | while read -d $'\0' file
+find . -type f -print0 | while read -r -d $'\0' file
 do
-  checkStaticLinking $file
+  checkStaticLinking "$file"
 done
-cd - > /dev/null
+)

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -6,21 +6,8 @@
 SOURCE=$1
 DESTINATION=$2
 
-# i want to centralize this function but everything is terrible
-# go read https://github.com/desktop/dugite-native/issues/38
-computeChecksum() {
-   if [ -z "$1" ] ; then
-     # no parameter provided, fail hard
-     exit 1
-   fi
-
-  path_to_sha256sum=$(which sha256sum)
-  if [ -x "$path_to_sha256sum" ] ; then
-    echo $(sha256sum $1 | awk '{print $1;}')
-  else
-    echo $(shasum -a 256 $1 | awk '{print $1;}')
-  fi
-}
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$CURRENT_DIR/compute-checksum.sh"
 
 echo "-- Building git at $SOURCE to $DESTINATION"
 
@@ -42,7 +29,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-darwin-amd64-v${GIT_LFS_VERSION}.tar.gz"
   echo "-- Downloading from $GIT_LFS_URL"
   curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
-  COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
+  COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/libexec/git-core"

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -12,7 +12,8 @@ source "$CURRENT_DIR/compute-checksum.sh"
 
 echo "-- Building git at $SOURCE to $DESTINATION"
 
-cd $SOURCE
+(
+cd "$SOURCE" || exit 1
 make clean
 DESTDIR="$DESTINATION" make strip install prefix=/ \
     NO_PERL=1 \
@@ -21,7 +22,7 @@ DESTDIR="$DESTINATION" make strip install prefix=/ \
     NO_DARWIN_PORTS=1 \
     NO_INSTALL_HARDLINKS=1 \
     MACOSX_DEPLOYMENT_TARGET=10.9
-cd - > /dev/null
+)
 
 
 if [[ "$GIT_LFS_VERSION" ]]; then
@@ -29,13 +30,13 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   GIT_LFS_FILE=git-lfs.tar.gz
   GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-darwin-amd64-v${GIT_LFS_VERSION}.tar.gz"
   echo "-- Downloading from $GIT_LFS_URL"
-  curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
+  curl -sL -o $GIT_LFS_FILE "$GIT_LFS_URL"
   COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/libexec/git-core"
     # strip out any text files when extracting the Git LFS archive
-    tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude='*.md'
+    tar -xvf $GIT_LFS_FILE -C "$SUBFOLDER" --exclude='*.sh' --exclude='*.md'
 
     if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
       echo "After extracting Git LFS the file was not found under libexec/git-core/"

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -7,6 +7,7 @@ SOURCE=$1
 DESTINATION=$2
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=script/compute-checksum.sh
 source "$CURRENT_DIR/compute-checksum.sh"
 
 echo "-- Building git at $SOURCE to $DESTINATION"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -7,21 +7,8 @@ SOURCE=$1
 DESTINATION=$2
 CURL_INSTALL_DIR=$3
 
-# i want to centralize this function but everything is terrible
-# go read https://github.com/desktop/dugite-native/issues/38
-computeChecksum() {
-   if [ -z "$1" ] ; then
-     # no parameter provided, fail hard
-     exit 1
-   fi
-
-  path_to_sha256sum=$(which sha256sum)
-  if [ -x "$path_to_sha256sum" ] ; then
-    echo $(sha256sum $1 | awk '{print $1;}')
-  else
-    echo $(shasum -a 256 $1 | awk '{print $1;}')
-  fi
-}
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$CURRENT_DIR/compute-checksum.sh"
 
 echo " -- Building vanilla curl at $CURL_INSTALL_DIR instead of distro-specific version"
 
@@ -55,14 +42,13 @@ DESTDIR="$DESTINATION" \
   make strip install
 cd - > /dev/null
 
-
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.tar.gz
   GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz"
   echo "-- Downloading from $GIT_LFS_URL"
   curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
-  COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
+  COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/libexec/git-core"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -18,24 +18,26 @@ echo " -- Building vanilla curl at $CURL_INSTALL_DIR instead of distro-specific 
 CURL_FILE_NAME="curl-7.61.1"
 CURL_FILE="$CURL_FILE_NAME.tar.gz"
 
-cd /tmp
+cd /tmp || exit 1
 curl -LO "https://curl.haxx.se/download/$CURL_FILE"
 tar -xf $CURL_FILE
-cd $CURL_FILE_NAME
-./configure --prefix=$CURL_INSTALL_DIR
-make install
-cd - > /dev/null
 
+(
+cd $CURL_FILE_NAME || exit 1
+./configure --prefix="$CURL_INSTALL_DIR"
+make install
+)
 echo " -- Building git at $SOURCE to $DESTINATION"
 
-cd $SOURCE
+(
+cd "$SOURCE" || exit 1
 make clean
 make configure
 CC='gcc' \
   CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
   LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro' \
   ./configure \
-  --with-curl=$CURL_INSTALL_DIR \
+  --with-curl="$CURL_INSTALL_DIR" \
   --prefix=/
 DESTDIR="$DESTINATION" \
   NO_TCLTK=1 \
@@ -43,19 +45,19 @@ DESTDIR="$DESTINATION" \
   NO_INSTALL_HARDLINKS=1 \
   NO_R_TO_GCC_LINKER=1 \
   make strip install
-cd - > /dev/null
+)
 
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.tar.gz
   GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz"
   echo "-- Downloading from $GIT_LFS_URL"
-  curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
+  curl -sL -o $GIT_LFS_FILE "$GIT_LFS_URL"
   COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/libexec/git-core"
-    tar -xvf $GIT_LFS_FILE -C $SUBFOLDER --exclude='*.sh' --exclude="*.md"
+    tar -xvf $GIT_LFS_FILE -C "$SUBFOLDER" --exclude='*.sh' --exclude="*.md"
 
     if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
       echo "After extracting Git LFS the file was not found under libexec/git-core/"
@@ -72,13 +74,14 @@ else
 fi
 
 
+(
 # download CA bundle and write straight to temp folder
 # for more information: https://curl.haxx.se/docs/caextract.html
 echo "-- Adding CA bundle"
-cd $DESTINATION
+cd "$DESTINATION" || exit 1
 mkdir -p ssl
 curl -sL -o ssl/cacert.pem https://curl.haxx.se/ca/cacert.pem
-cd - > /dev/null
+)
 
 if [[ ! -f "$DESTINATION/ssl/cacert.pem" ]]; then
   echo "-- Skipped bundling of CA certificates (failed to download them)"
@@ -97,44 +100,18 @@ rm "$DESTINATION/libexec/git-core/git-svn"
 rm "$DESTINATION/libexec/git-core/git-remote-testsvn"
 rm "$DESTINATION/libexec/git-core/git-p4"
 
-
-checkStaticLinking() {
-  if [ -z "$1" ] ; then
-    # no parameter provided, fail hard
-    exit 1
-  fi
-
-  # ermagherd there's two whitespace characters between 'LSB' and 'executable'
-  # when running this on Travis - why is everything so terrible?
-  if file $1 | grep -q 'ELF 64-bit LSB'; then
-    if readelf -d $1 | grep -q 'Shared library'; then
-      echo "File: $file"
-      # this is done twice rather than storing in a bash variable because
-      # it's easier than trying to preserve the line endings
-      echo "readelf output:"
-      readelf -d $1 | grep 'Shared library'
-      # get a list of glibc versions required by the binary
-      echo "objdump GLIBC output:"
-      objdump -T $1 | grep -oEi 'GLIBC_[0-9]*.[0-9]*.[0-9]*'| sort | uniq
-      # confirm what version of curl is expected
-      echo "objdump curl output:"
-      objdump -T $1 | grep -oEi " curl.*" | sort | uniq
-      echo ""
-    fi
-  fi
-}
-
 echo "-- Static linking research"
 check_static_linking "$DESTINATION"
 
 echo "-- Testing clone operation with generated binary"
 
-rm -rf $CURL_OUTPUT_DIR
+rm -rf "$CURL_OUTPUT_DIR"
 
 TEMP_CLONE_DIR=/tmp/clones
 mkdir -p $TEMP_CLONE_DIR
 
-cd "$DESTINATION/bin"
+(
+cd "$DESTINATION/bin" || exit 1
 ./git --version
 GIT_CURL_VERBOSE=1 \
   GIT_TEMPLATE_DIR="$DESTINATION/share/git-core/templates" \
@@ -142,4 +119,4 @@ GIT_CURL_VERBOSE=1 \
   GIT_EXEC_PATH="$DESTINATION/libexec/git-core" \
   PREFIX="$DESTINATION" \
   ./git clone https://github.com/git/git.github.io "$TEMP_CLONE_DIR/git.github.io"
-cd - > /dev/null
+)

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -9,6 +9,7 @@ CURL_INSTALL_DIR=$3
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/compute-checksum.sh"
+source "$CURRENT_DIR/check-static-linking.sh"
 
 echo " -- Building vanilla curl at $CURL_INSTALL_DIR instead of distro-specific version"
 
@@ -122,13 +123,7 @@ checkStaticLinking() {
 }
 
 echo "-- Static linking research"
-cd "$DESTINATION"
-# check all files for ELF exectuables
-find . -type f -print0 | while read -d $'\0' file
-do
-  checkStaticLinking $file
-done
-cd - > /dev/null
+check_static_linking "$DESTINATION"
 
 echo "-- Testing clone operation with generated binary"
 

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -8,7 +8,9 @@ DESTINATION=$2
 CURL_INSTALL_DIR=$3
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=script/compute-checksum.sh
 source "$CURRENT_DIR/compute-checksum.sh"
+# shellcheck source=script/check-static-linking.sh
 source "$CURRENT_DIR/check-static-linking.sh"
 
 echo " -- Building vanilla curl at $CURL_INSTALL_DIR instead of distro-specific version"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -9,17 +9,17 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=script/compute-checksum.sh
 source "$CURRENT_DIR/compute-checksum.sh"
 
-mkdir -p $DESTINATION
+mkdir -p "$DESTINATION"
 
 if [ "$WIN_ARCH" -eq "64" ]; then MINGW_DIR="mingw64"; else MINGW_DIR="mingw32"; fi
 
 echo "-- Downloading MinGit from $GIT_FOR_WINDOWS_URL"
 GIT_FOR_WINDOWS_FILE=git-for-windows.zip
-curl -sL -o $GIT_FOR_WINDOWS_FILE $GIT_FOR_WINDOWS_URL
+curl -sL -o $GIT_FOR_WINDOWS_FILE "$GIT_FOR_WINDOWS_URL"
 COMPUTED_SHA256=$(compute_checksum $GIT_FOR_WINDOWS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_FOR_WINDOWS_CHECKSUM" ]; then
   echo "MinGit: checksums match"
-  unzip -qq $GIT_FOR_WINDOWS_FILE -d $DESTINATION
+  unzip -qq $GIT_FOR_WINDOWS_FILE -d "$DESTINATION"
 else
   echo "MinGit: expected checksum $GIT_FOR_WINDOWS_CHECKSUM but got $COMPUTED_SHA256"
   echo "aborting..."
@@ -34,12 +34,12 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   if [ "$WIN_ARCH" -eq "64" ]; then GIT_LFS_ARCH="amd64"; else GIT_LFS_ARCH="386"; fi
   GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-windows-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.zip"
   echo "-- Downloading from $GIT_LFS_URL"
-  curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
+  curl -sL -o $GIT_LFS_FILE "$GIT_LFS_URL"
   COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/$MINGW_DIR/libexec/git-core"
-    unzip -j $GIT_LFS_FILE -x '*.md' -d $SUBFOLDER
+    unzip -j $GIT_LFS_FILE -x '*.md' -d "$SUBFOLDER"
 
     # this is a workaround because Git LFS changed the names of the files in the archive
     OLD_FILE_NAME="git-lfs-windows-$GIT_LFS_ARCH.exe"
@@ -63,16 +63,16 @@ fi
 SYSTEM_CONFIG="$DESTINATION/$MINGW_DIR/etc/gitconfig"
 
 echo "-- Setting some system configuration values"
-git config --file $SYSTEM_CONFIG core.symlinks "false"
-git config --file $SYSTEM_CONFIG core.autocrlf "true"
-git config --file $SYSTEM_CONFIG core.fscache "true"
-git config --file $SYSTEM_CONFIG http.sslBackend "schannel"
+git config --file "$SYSTEM_CONFIG" core.symlinks "false"
+git config --file "$SYSTEM_CONFIG" core.autocrlf "true"
+git config --file "$SYSTEM_CONFIG" core.fscache "true"
+git config --file "$SYSTEM_CONFIG" http.sslBackend "schannel"
 
 # See https://github.com/desktop/desktop/issues/4817#issuecomment-393241303
 # Even though it's not set openssl will auto-discover the one we ship because
 # it sits in the right location already. So users manually switching
 # http.sslBackend to openssl will still pick it up.
-git config --file $SYSTEM_CONFIG --unset http.sslCAInfo
+git config --file "$SYSTEM_CONFIG" --unset http.sslCAInfo
 
 # Git for Windows 2.18.1 will support controlling how curl uses any certificate
 # bundle - rather than just loading the bundle if http.useSSLCAInfo is set
@@ -80,7 +80,7 @@ git config --file $SYSTEM_CONFIG --unset http.sslCAInfo
 # user has overriden this in their global configuration.
 #
 # details: https://github.com/dscho/git/blob/6152657e1a97c478df97d633c47469043b397519/Documentation/config.txt#L2135
-git config --file $SYSTEM_CONFIG http.schannelUseSSLCAInfo "false"
+git config --file "$SYSTEM_CONFIG" http.schannelUseSSLCAInfo "false"
 
 # removing global gitattributes file
 rm "$DESTINATION/$MINGW_DIR/etc/gitattributes"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -3,23 +3,11 @@
 # Repackaging Git for Windows and bundling Git LFS from upstream.
 #
 
-# i want to centralize this function but everything is terrible
-# go read https://github.com/desktop/dugite-native/issues/38
-computeChecksum() {
-   if [ -z "$1" ] ; then
-     # no parameter provided, fail hard
-     exit 1
-   fi
-
-  path_to_sha256sum=$(which sha256sum)
-  if [ -x "$path_to_sha256sum" ] ; then
-    echo $(sha256sum $1 | awk '{print $1;}')
-  else
-    echo $(shasum -a 256 $1 | awk '{print $1;}')
-  fi
-}
-
 DESTINATION=$1
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$CURRENT_DIR/compute-checksum.sh"
+
 mkdir -p $DESTINATION
 
 if [ "$WIN_ARCH" -eq "64" ]; then MINGW_DIR="mingw64"; else MINGW_DIR="mingw32"; fi
@@ -46,7 +34,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-windows-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.zip"
   echo "-- Downloading from $GIT_LFS_URL"
   curl -sL -o $GIT_LFS_FILE $GIT_LFS_URL
-  COMPUTED_SHA256=$(computeChecksum $GIT_LFS_FILE)
+  COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/$MINGW_DIR/libexec/git-core"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -6,6 +6,7 @@
 DESTINATION=$1
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=script/compute-checksum.sh
 source "$CURRENT_DIR/compute-checksum.sh"
 
 mkdir -p $DESTINATION

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -15,7 +15,7 @@ if [ "$WIN_ARCH" -eq "64" ]; then MINGW_DIR="mingw64"; else MINGW_DIR="mingw32";
 echo "-- Downloading MinGit from $GIT_FOR_WINDOWS_URL"
 GIT_FOR_WINDOWS_FILE=git-for-windows.zip
 curl -sL -o $GIT_FOR_WINDOWS_FILE $GIT_FOR_WINDOWS_URL
-COMPUTED_SHA256=$(computeChecksum $GIT_FOR_WINDOWS_FILE)
+COMPUTED_SHA256=$(compute_checksum $GIT_FOR_WINDOWS_FILE)
 if [ "$COMPUTED_SHA256" = "$GIT_FOR_WINDOWS_CHECKSUM" ]; then
   echo "MinGit: checksums match"
   unzip -qq $GIT_FOR_WINDOWS_FILE -d $DESTINATION

--- a/script/build.sh
+++ b/script/build.sh
@@ -4,20 +4,20 @@
 # Platforms have different ways to build Git and prepare the environment
 # for packaging, so defer to the `build-*` files for more details
 #
-BASEDIR=`pwd`
+BASEDIR=$(pwd)
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE="${BASEDIR}/git"
 DESTINATION="/tmp/build/git"
 CURL_INSTALL_DIR="/tmp/build/curl"
 
 if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
-  bash "$DIR/build-ubuntu.sh" $SOURCE $DESTINATION $CURL_INSTALL_DIR
+  bash "$DIR/build-ubuntu.sh" "$SOURCE" $DESTINATION $CURL_INSTALL_DIR
 elif [ "$TARGET_PLATFORM" == "macOS" ]; then
-  bash "$DIR/build-macos.sh" $SOURCE $DESTINATION
+  bash "$DIR/build-macos.sh" "$SOURCE" $DESTINATION
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
   bash "$DIR/build-win32.sh" $DESTINATION
 elif [ "$TARGET_PLATFORM" == "arm64" ]; then
-  bash "$DIR/build-arm64.sh" $SOURCE $DESTINATION $CURL_INSTALL_DIR $BASEDIR
+  bash "$DIR/build-arm64.sh" "$SOURCE" "$DESTINATION" "$CURL_INSTALL_DIR" "$BASEDIR"
 else
   echo "Unable to build Git for platform $TARGET_PLATFORM"
   exit 1

--- a/script/check-static-linking.sh
+++ b/script/check-static-linking.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+#
+# General purpose functions for inspecting generated ELF binaries to understand
+# static and dynamic linking details as part of the build process
 
 check_static_linking_file() {
   if [ -z "$1" ] ; then

--- a/script/check-static-linking.sh
+++ b/script/check-static-linking.sh
@@ -1,0 +1,39 @@
+
+check_static_linking_file() {
+  if [ -z "$1" ] ; then
+    # no parameter provided, fail hard
+    exit 1
+  fi
+
+  # ermagherd there's two whitespace characters between 'LSB' and 'executable'
+  # when running this on Travis - why is everything so terrible?
+  if file "$1" | grep -q 'ELF 64-bit LSB'; then
+    if readelf -d "$1" | grep -q 'Shared library'; then
+      echo "File: $file"
+      # this is done twice rather than storing in a bash variable because
+      # it's easier than trying to preserve the line endings
+      echo "readelf output:"
+      readelf -d "$1" | grep 'Shared library'
+      # get a list of glibc versions required by the binary
+      echo "objdump GLIBC output:"
+      objdump -T "$1" | grep -oEi 'GLIBC_[0-9]*.[0-9]*.[0-9]*'| sort | uniq
+      # confirm what version of curl is expected
+      echo "objdump curl output:"
+      objdump -T "$1" | grep -oEi " curl.*" | sort | uniq
+      echo ""
+    fi
+  fi
+}
+
+check_static_linking() {
+  if [ -z "$1" ] ; then
+    # no parameter provided, fail hard
+    exit 1
+  fi
+
+  # check all files for ELF exectuables
+  find "$1" -type f -print0 | while read -r -d $'\0' file
+  do
+    check_static_linking_file "$file"
+  done
+}

--- a/script/compute-checksum.sh
+++ b/script/compute-checksum.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# general purpose function for obtaining the SHA256 checksum of a file
+#
+# path to the file should be the first argument
+
+compute_checksum() {
+   if [ -z "$1" ] ; then
+     # no parameter provided, fail hard
+     exit 1
+   fi
+
+  FILE=$1
+
+  path_to_sha256sum=$(command -v sha256sum)
+  if [ -x "$path_to_sha256sum" ] ; then
+    sha256sum "$FILE" | awk '{print $1;}'
+  else
+    shasum -a 256 "$FILE" | awk '{print $1;}'
+  fi
+}

--- a/script/compute-checksum.sh
+++ b/script/compute-checksum.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-# general purpose function for obtaining the SHA256 checksum of a file
+#
+# General purpose function for obtaining the SHA256 checksum of a file
 #
 # path to the file should be the first argument
 

--- a/script/package.sh
+++ b/script/package.sh
@@ -6,19 +6,24 @@
 # intended to be part of the archive.
 #
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE="./git"
 DESTINATION="/tmp/build/git"
 
-cd $SOURCE
-VERSION=$(git describe --exact-match HEAD)
-EXIT_CODE=$?
+# shellcheck source=script/compute-checksum.sh
+source "$CURRENT_DIR/compute-checksum.sh"
 
-if [ "$EXIT_CODE" == "128" ]; then
-  echo "Git commit does not have tag, cannot use version to build from"
-  exit 1
-fi
-cd - > /dev/null
+VERSION=$(
+  cd $SOURCE || exit 1
+  VERSION=$(git describe --exact-match HEAD)
+  EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" == "128" ]; then
+    echo "Git commit does not have tag, cannot use version to build from"
+    exit 1
+  fi
+  echo "$VERSION"
+)
 
 BUILD_HASH=$(git rev-parse --short HEAD)
 
@@ -45,33 +50,29 @@ else
   exit 1
 fi
 
+(
 echo ""
 echo "Creating archives..."
 mkdir output
-cd output
+cd output || exit 1
 if [ "$(uname -s)" == "Darwin" ]; then
-  tar -czf $GZIP_FILE -C $DESTINATION .
-  tar --lzma -cf $LZMA_FILE -C $DESTINATION .
+  tar -czf "$GZIP_FILE" -C $DESTINATION .
+  tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
 else
-  tar -caf $GZIP_FILE -C $DESTINATION .
-  tar -caf $LZMA_FILE -C $DESTINATION .
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
+  tar -caf "$LZMA_FILE" -C $DESTINATION .
 fi
 
-if [ "$APPVEYOR" == "True" ]; then
-  GZIP_CHECKSUM=$(sha256sum $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(sha256sum $LZMA_FILE | awk '{print $1;}')
-else
-  GZIP_CHECKSUM=$(shasum -a 256 $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
-fi
+GZIP_CHECKSUM=$(compute_checksum "$GZIP_FILE")
+LZMA_CHECKSUM=$(compute_checksum "$LZMA_FILE")
 
 echo "$GZIP_CHECKSUM" | tr -d '\n' > "${GZIP_FILE}.sha256"
 echo "$LZMA_CHECKSUM" | tr -d '\n' > "${LZMA_FILE}.sha256"
 
-GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
-LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+GZIP_SIZE=$(du -h "$GZIP_FILE" | cut -f1)
+LZMA_SIZE=$(du -h "$LZMA_FILE" | cut -f1)
 
 echo "Packages created:"
 echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"
 echo "${LZMA_FILE} - ${LZMA_SIZE} - checksum: ${LZMA_CHECKSUM}"
-cd - > /dev/null
+)

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -67,7 +67,11 @@ const platforms = yaml['matrix']['include']
 
 for (const platform of platforms) {
   const platformEnv = platform['env']
-  const env = [ ... globalEnv, ...platformEnv ]
+  if (platformEnv == null) {
+    continue
+  }
+
+  const env = [...globalEnv, ...platformEnv]
 
   const target = platformEnv[0]
   const keys = target.split('=')

--- a/script/verify-arm64-git.sh
+++ b/script/verify-arm64-git.sh
@@ -1,13 +1,14 @@
 echo "-- Test compiled Git LFS"
 
-$DESTINATION/libexec/git-core/git-lfs --version
+"$DESTINATION/libexec/git-core/git-lfs" --version
 
 echo "-- Test clone operation with generated binary"
 
 TEMP_CLONE_DIR=/tmp/clones
 mkdir -p $TEMP_CLONE_DIR
 
-cd "$DESTINATION/bin"
+(
+cd "$DESTINATION/bin" || exit 1
 ./git --version
 GIT_CURL_VERBOSE=1 \
   GIT_TEMPLATE_DIR="$DESTINATION/share/git-core/templates" \
@@ -15,4 +16,4 @@ GIT_CURL_VERBOSE=1 \
   GIT_EXEC_PATH="$DESTINATION/libexec/git-core" \
   PREFIX="$DESTINATION" \
   ./git clone https://github.com/git/git.github.io "$TEMP_CLONE_DIR/git.github.io"
-cd - > /dev/null
+)

--- a/script/verify-arm64-git.sh
+++ b/script/verify-arm64-git.sh
@@ -1,4 +1,11 @@
-echo "-- Test compiled Git LFS"
+#!/bin/bash
+#
+# Verify Git for ARM64 Linux (should be run inside a container)
+#
+# Required environment variables:
+# - DESTINATION
+
+echo "-- Test external Git LFS"
 
 "$DESTINATION/libexec/git-core/git-lfs" --version
 


### PR DESCRIPTION
- [x] confirm travis build fails when shellcheck fails
- [x] address suggestions
- [x] confirm all builds are still green and generating artifacts