### PR TITLE
push more parameters into environment variables

### DIFF
--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 #
 # Compiling Git for ARM64 Linux (should be run inside a container)
-#
-# Required environment variables:
-# - SOURCE
-# - DESTINATION
-# - CURL_INSTALL_DIR
+
+if [[ -z "${SOURCE}" ]]; then
+  echo "Required environment variable SOURCE was not set"
+  exit 1
+fi
+
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
+
+if [[ -z "${CURL_INSTALL_DIR}" ]]; then
+  echo "Required environment variable CURL_INSTALL_DIR was not set"
+  exit 1
+fi
 
 echo " -- Building git at $SOURCE to $DESTINATION"
 

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Compiling Git for ARM64 Linux (should be run inside a container)
 

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -3,10 +3,26 @@
 # Building Git for ARM64 Linux and bundling Git LFS from upstream.
 #
 
-SOURCE=$1
-DESTINATION=$2
-CURL_INSTALL_DIR=$3
-BASEDIR=$4
+if [[ -z "${SOURCE}" ]]; then
+  echo "Required environment variable SOURCE was not set"
+  exit 1
+fi
+
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
+
+if [[ -z "${CURL_INSTALL_DIR}" ]]; then
+  echo "Required environment variable CURL_INSTALL_DIR was not set"
+  exit 1
+fi
+
+if [[ -z "${BASEDIR}" ]]; then
+  echo "Required environment variable BASEDIR was not set"
+  exit 1
+fi
+
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=script/compute-checksum.sh

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Building Git for ARM64 Linux and bundling Git LFS from upstream.
 #

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Compiling Git for macOS and bundling Git LFS from upstream.
 #

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -3,8 +3,15 @@
 # Compiling Git for macOS and bundling Git LFS from upstream.
 #
 
-SOURCE=$1
-DESTINATION=$2
+if [[ -z "${SOURCE}" ]]; then
+  echo "Required environment variable SOURCE was not set"
+  exit 1
+fi
+
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=script/compute-checksum.sh

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -3,9 +3,20 @@
 # Compiling Git for Linux and bundling Git LFS from upstream.
 #
 
-SOURCE=$1
-DESTINATION=$2
-CURL_INSTALL_DIR=$3
+if [[ -z "${SOURCE}" ]]; then
+  echo "Required environment variable SOURCE was not set"
+  exit 1
+fi
+
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
+
+if [[ -z "${CURL_INSTALL_DIR}" ]]; then
+  echo "Required environment variable CURL_INSTALL_DIR was not set"
+  exit 1
+fi
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=script/compute-checksum.sh

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Compiling Git for Linux and bundling Git LFS from upstream.
 #
+
 
 if [[ -z "${SOURCE}" ]]; then
   echo "Required environment variable SOURCE was not set"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -3,7 +3,10 @@
 # Repackaging Git for Windows and bundling Git LFS from upstream.
 #
 
-DESTINATION=$1
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=script/compute-checksum.sh

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Repackaging Git for Windows and bundling Git LFS from upstream.
 #

--- a/script/build.sh
+++ b/script/build.sh
@@ -19,10 +19,10 @@ else
   exit 1
 fi
 
-BASEDIR=$(dirname $CURRENT_DIR)
+ROOT=$(dirname "$CURRENT_DIR")
 
-SOURCE="${BASEDIR}/git" \
+BASEDIR=$ROOT \
+  SOURCE="$ROOT/git" \
   DESTINATION="/tmp/build/git" \
   CURL_INSTALL_DIR="/tmp/build/curl" \
-  BASEDIR=$BASEDIR \
   bash "$SCRIPT"

--- a/script/build.sh
+++ b/script/build.sh
@@ -19,8 +19,10 @@ else
   exit 1
 fi
 
+BASEDIR=$(dirname $CURRENT_DIR)
+
 SOURCE="${BASEDIR}/git" \
   DESTINATION="/tmp/build/git" \
   CURL_INSTALL_DIR="/tmp/build/curl" \
-  BASEDIR=$(pwd) \
+  BASEDIR=$BASEDIR \
   bash "$SCRIPT"

--- a/script/build.sh
+++ b/script/build.sh
@@ -5,20 +5,22 @@
 # for packaging, so defer to the `build-*` files for more details
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-export SOURCE="${BASEDIR}/git"
-export DESTINATION="/tmp/build/git"
-export CURL_INSTALL_DIR="/tmp/build/curl"
 
 if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
-  bash "$CURRENT_DIR/build-ubuntu.sh"
+  SCRIPT="$CURRENT_DIR/build-ubuntu.sh"
 elif [ "$TARGET_PLATFORM" == "macOS" ]; then
-  bash "$CURRENT_DIR/build-macos.sh"
+  SCRIPT="$CURRENT_DIR/build-macos.sh"
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
-  bash "$CURRENT_DIR/build-win32.sh"
+  SCRIPT="$CURRENT_DIR/build-win32.sh"
 elif [ "$TARGET_PLATFORM" == "arm64" ]; then
-  export BASEDIR=$(pwd)
-  bash "$CURRENT_DIR/build-arm64.sh"
+  SCRIPT="$CURRENT_DIR/build-arm64.sh"
 else
   echo "Unable to build Git for platform $TARGET_PLATFORM"
   exit 1
 fi
+
+SOURCE="${BASEDIR}/git" \
+  DESTINATION="/tmp/build/git" \
+  CURL_INSTALL_DIR="/tmp/build/curl" \
+  BASEDIR=$(pwd) \
+  bash "$SCRIPT"

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Entry point to build process to support different platforms.
 # Platforms have different ways to build Git and prepare the environment
 # for packaging, so defer to the `build-*` files for more details
-#
+
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck disable=SC2034
 SOURCE="${BASEDIR}/git"

--- a/script/build.sh
+++ b/script/build.sh
@@ -5,12 +5,9 @@
 # for packaging, so defer to the `build-*` files for more details
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-# shellcheck disable=SC2034
-SOURCE="${BASEDIR}/git"
-# shellcheck disable=SC2034
-DESTINATION="/tmp/build/git"
-# shellcheck disable=SC2034
-CURL_INSTALL_DIR="/tmp/build/curl"
+export SOURCE="${BASEDIR}/git"
+export DESTINATION="/tmp/build/git"
+export CURL_INSTALL_DIR="/tmp/build/curl"
 
 if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
   bash "$CURRENT_DIR/build-ubuntu.sh"
@@ -19,7 +16,7 @@ elif [ "$TARGET_PLATFORM" == "macOS" ]; then
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
   bash "$CURRENT_DIR/build-win32.sh"
 elif [ "$TARGET_PLATFORM" == "arm64" ]; then
-  BASEDIR=$(pwd)
+  export BASEDIR=$(pwd)
   bash "$CURRENT_DIR/build-arm64.sh"
 else
   echo "Unable to build Git for platform $TARGET_PLATFORM"

--- a/script/build.sh
+++ b/script/build.sh
@@ -4,20 +4,23 @@
 # Platforms have different ways to build Git and prepare the environment
 # for packaging, so defer to the `build-*` files for more details
 #
-BASEDIR=$(pwd)
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck disable=SC2034
 SOURCE="${BASEDIR}/git"
+# shellcheck disable=SC2034
 DESTINATION="/tmp/build/git"
+# shellcheck disable=SC2034
 CURL_INSTALL_DIR="/tmp/build/curl"
 
 if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
-  bash "$DIR/build-ubuntu.sh" "$SOURCE" $DESTINATION $CURL_INSTALL_DIR
+  bash "$CURRENT_DIR/build-ubuntu.sh"
 elif [ "$TARGET_PLATFORM" == "macOS" ]; then
-  bash "$DIR/build-macos.sh" "$SOURCE" $DESTINATION
+  bash "$CURRENT_DIR/build-macos.sh"
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
-  bash "$DIR/build-win32.sh" $DESTINATION
+  bash "$CURRENT_DIR/build-win32.sh"
 elif [ "$TARGET_PLATFORM" == "arm64" ]; then
-  bash "$DIR/build-arm64.sh" "$SOURCE" "$DESTINATION" "$CURL_INSTALL_DIR" "$BASEDIR"
+  BASEDIR=$(pwd)
+  bash "$CURRENT_DIR/build-arm64.sh"
 else
   echo "Unable to build Git for platform $TARGET_PLATFORM"
   exit 1

--- a/script/check-static-linking.sh
+++ b/script/check-static-linking.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # General purpose functions for inspecting generated ELF binaries to understand
 # static and dynamic linking details as part of the build process

--- a/script/compute-checksum.sh
+++ b/script/compute-checksum.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # General purpose function for obtaining the SHA256 checksum of a file
 #

--- a/script/package.sh
+++ b/script/package.sh
@@ -1,10 +1,9 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Script for packaging artefacts into gzipped archive.
 # Build scripts should handle platform-specific differences, so this
 # script works off the assumption that everything at $DESTINATION is
 # intended to be part of the archive.
-#
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE="./git"

--- a/script/verify-arm64-git.sh
+++ b/script/verify-arm64-git.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 #
 # Verify Git for ARM64 Linux (should be run inside a container)
-#
-# Required environment variables:
-# - DESTINATION
+
+if [[ -z "${DESTINATION}" ]]; then
+  echo "Required environment variable DESTINATION was not set"
+  exit 1
+fi
 
 echo "-- Test external Git LFS"
 

--- a/script/verify-arm64-git.sh
+++ b/script/verify-arm64-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Verify Git for ARM64 Linux (should be run inside a container)
 


### PR DESCRIPTION
Rather than mixing up script arguments (the old way I was passing things in) and environment variables (the easier way to pass things when running inside Docker) this PR tries to standardize on using environment variables. We were pretty consistent with names inside the scripts, so this should not be a big deal.

This PR also adds runtime checks to ensure the environment variables, so we can fail the scripts fast if the preconditions aren't set.

 - [x] no errors reported in scripts
 - [x] all builds are creating artefacts 