### PR TITLE
make the publish step Windows-aware

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
   WIN_ARCH: 64
   GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip
   GIT_FOR_WINDOWS_CHECKSUM: f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3
-  GIT_LFS_VERSION: 2.5.2
-  GIT_LFS_CHECKSUM: d5276eb61dea32b3978c2f68c5cf3ad4a45bf70f1a245ddc86b555db7299c7c9
+  GIT_LFS_VERSION: 2.6.0
+  GIT_LFS_CHECKSUM: f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279
 
 build_script:
   - cmd: git submodule update --init --recursive

--- a/script/package.sh
+++ b/script/package.sh
@@ -59,7 +59,8 @@ if [[ "$OSTYPE" == "darwin*" ]]; then
   tar -czf "$GZIP_FILE" -C $DESTINATION .
   tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
 elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
-  echo "TODO: running on a Windows OS, need to use a different zip tool as lzma is missing"
+  echo "Using 7z to generate the lzma file because the host doesn't have a working environment for tar to do this natively"
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
   7z --help
   exit 1
 else

--- a/script/package.sh
+++ b/script/package.sh
@@ -66,7 +66,7 @@ elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
   # being the native format of 7z files
   NEW_LZMA_FILE="dugite-native-$VERSION-win32-test.7z"
   7z u -t7z "$NEW_LZMA_FILE" $DESTINATION/*
-  mv $NEW_LZMA_FILE $LZMA_FILE
+  mv "$NEW_LZMA_FILE" "$LZMA_FILE"
 else
   echo "Using unix tar by default"
   tar -caf "$GZIP_FILE" -C $DESTINATION .

--- a/script/package.sh
+++ b/script/package.sh
@@ -60,6 +60,7 @@ if [ "$PLATFORM" == "Darwin" ]; then
   tar -czf "$GZIP_FILE" -C $DESTINATION .
   tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
 elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  echo "Using tar and 7z here because tar is unable to access lzma compression on Windows"
   tar -caf "$GZIP_FILE" -C $DESTINATION .
   # hacking around the fact that 7z refuses to write to LZMA files despite them
   # being the native format of 7z files

--- a/script/package.sh
+++ b/script/package.sh
@@ -51,13 +51,19 @@ fi
 
 (
 echo ""
-echo "Creating archives..."
+echo "Creating archives for platform ${OSTYPE}..."
 mkdir output
 cd output || exit 1
-if [ "$(uname -s)" == "Darwin" ]; then
+if [[ "$OSTYPE" == "darwin*" ]]; then
+  echo "Using bsdtar which has some different command flags"
   tar -czf "$GZIP_FILE" -C $DESTINATION .
   tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
+elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  echo "TODO: running on a Windows OS, need to use a different zip tool as lzma is missing"
+  7z --help
+  exit 1
 else
+  echo "Using unix tar by default"
   tar -caf "$GZIP_FILE" -C $DESTINATION .
   tar -caf "$LZMA_FILE" -C $DESTINATION .
 fi

--- a/script/package.sh
+++ b/script/package.sh
@@ -60,10 +60,12 @@ if [ "$PLATFORM" == "Darwin" ]; then
   tar -czf "$GZIP_FILE" -C $DESTINATION .
   tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
 elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
-  echo "Using 7z to generate the lzma file because the host doesn't have a working environment for tar to do this natively"
   tar -caf "$GZIP_FILE" -C $DESTINATION .
-  7z --help
-  exit 1
+  # hacking around the fact that 7z refuses to write to LZMA files despite them
+  # being the native format of 7z files
+  NEW_LZMA_FILE="dugite-native-$VERSION-win32-test.7z"
+  7z u -t7z "$NEW_LZMA_FILE" $DESTINATION/*
+  mv $NEW_LZMA_FILE $LZMA_FILE
 else
   echo "Using unix tar by default"
   tar -caf "$GZIP_FILE" -C $DESTINATION .

--- a/script/package.sh
+++ b/script/package.sh
@@ -51,10 +51,11 @@ fi
 
 (
 echo ""
-echo "Creating archives for platform ${OSTYPE}..."
+PLATFORM=$(uname -s)
+echo "Creating archives for $PLATFORM (${OSTYPE})..."
 mkdir output
 cd output || exit 1
-if [[ "$OSTYPE" == "darwin*" ]]; then
+if [ "$PLATFORM" == "Darwin" ]; then
   echo "Using bsdtar which has some different command flags"
   tar -czf "$GZIP_FILE" -C $DESTINATION .
   tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -73,6 +73,7 @@ if [ "$PLATFORM" == "Darwin" ]; then
   tar -czf "$GZIP_FILE" -C $DESTINATION .
   tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
 elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  echo "Using tar and 7z here because tar is unable to access lzma compression on Windows"
   tar -caf "$GZIP_FILE" -C $DESTINATION .
   # hacking around the fact that 7z refuses to write to LZMA files despite them
   # being the native format of 7z files

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -3,54 +3,100 @@ const path = require('path')
 const YAML = require('node-yaml')
 
 function writeEnvironmentToFile(os, env) {
-  const environmentVariables = env.map(a => `${a} \\`).join('\n')
+  const environmentVariables = env.map(a => `${a}`).join('\n')
 
   const script = `build-${os}.sh`
   const fileContents = `#!/bin/bash
 
-DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
-ROOT="$DIR/.."
+${environmentVariables}
+
+CURRENT_DIR="$( cd "$( dirname "\$\{BASH_SOURCE[0]\}" )" && pwd )"
+ROOT="$CURRENT_DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-${environmentVariables}
 . "$ROOT/script/${script}" $SOURCE $DESTINATION
+
+source "$ROOT/script/compute-checksum.sh"
+
+VERSION=$(
+  cd $SOURCE || exit 1
+  VERSION=$(git describe --exact-match HEAD)
+  EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" == "128" ]; then
+    echo "Git commit does not have tag, cannot use version to build from"
+    exit 1
+  fi
+  echo "$VERSION"
+)
 
 echo "Archive contents:"
 cd $DESTINATION
 du -ah $DESTINATION
 cd - > /dev/null
 
-GZIP_FILE="dugite-native-$VERSION-${os}-test.tar.gz"
-LZMA_FILE="dugite-native-$VERSION-${os}-test.lzma"
+BUILD_HASH=$(git rev-parse --short HEAD)
 
+if ! [ -d "$DESTINATION" ]; then
+  echo "No output found, exiting..."
+  exit 1
+fi
+
+if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.lzma"
+elif [ "$TARGET_PLATFORM" == "macOS" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.lzma"
+elif [ "$TARGET_PLATFORM" == "win32" ]; then
+  if [ "$WIN_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="x86"; fi
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.lzma"
+elif [ "$TARGET_PLATFORM" == "arm64" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.lzma"
+else
+  echo "Unable to package Git for platform $TARGET_PLATFORM"
+  exit 1
+fi
+
+(
 echo ""
-echo "Creating archives..."
-if [ "$(uname -s)" == "Darwin" ]; then
-  tar -czf $GZIP_FILE -C $DESTINATION .
-  tar --lzma -cf $LZMA_FILE -C $DESTINATION .
+PLATFORM=$(uname -s)
+echo "Creating archives for $PLATFORM (\$\{OSTYPE\})..."
+mkdir output
+cd output || exit 1
+if [ "$PLATFORM" == "Darwin" ]; then
+  echo "Using bsdtar which has some different command flags"
+  tar -czf "$GZIP_FILE" -C $DESTINATION .
+  tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
+elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
+  # hacking around the fact that 7z refuses to write to LZMA files despite them
+  # being the native format of 7z files
+  NEW_LZMA_FILE="dugite-native-$VERSION-win32-test.7z"
+  7z u -t7z "$NEW_LZMA_FILE" $DESTINATION/*
+  mv $NEW_LZMA_FILE $LZMA_FILE
 else
-  tar -caf $GZIP_FILE -C $DESTINATION .
-  tar -caf $LZMA_FILE -C $DESTINATION .
+  echo "Using unix tar by default"
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
+  tar -caf "$LZMA_FILE" -C $DESTINATION .
 fi
 
-if [ "$APPVEYOR" == "True" ]; then
-  GZIP_CHECKSUM=$(sha256sum $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(sha256sum $LZMA_FILE | awk '{print $1;}')
-else
-  GZIP_CHECKSUM=$(shasum -a 256 $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
-fi
+GZIP_CHECKSUM=$(compute_checksum "$GZIP_FILE")
+LZMA_CHECKSUM=$(compute_checksum "$LZMA_FILE")
 
-GZIP_SIZE=\$(du -h $GZIP_FILE | cut -f1)
-LZMA_SIZE=\$(du -h $LZMA_FILE | cut -f1)
+GZIP_SIZE=$(du -h "$GZIP_FILE" | cut -f1)
+LZMA_SIZE=$(du -h "$LZMA_FILE" | cut -f1)
 
 echo "$\{GZIP_CHECKSUM}" | tr -d '\\n' > "\${GZIP_FILE}.sha256"
 echo "$\{LZMA_CHECKSUM}" | tr -d '\\n' > "\${LZMA_FILE}.sha256"
 
 echo "Packages created:"
 echo "\${GZIP_FILE} - \${GZIP_SIZE} - checksum: \${GZIP_CHECKSUM}"
-echo "\${LZMA_FILE} - \${LZMA_SIZE} - checksum: \${LZMA_CHECKSUM}"`
+echo "\${LZMA_FILE} - \${LZMA_SIZE} - checksum: \${LZMA_CHECKSUM}"
+)`
 
   const destination = path.resolve(__dirname, '..', `test/${os}.sh`)
   fs.writeFileSync(destination, fileContents, { encoding: 'utf-8', mode: '777' })

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -31,10 +31,11 @@ VERSION=$(
   echo "$VERSION"
 )
 
-echo "Archive contents:"
+(
+echo "Generated bits to package at $DESTINATION:"
 cd $DESTINATION
-du -ah $DESTINATION
-cd - > /dev/null
+find .
+)
 
 BUILD_HASH=$(git rev-parse --short HEAD)
 

--- a/test/macos.sh
+++ b/test/macos.sh
@@ -67,6 +67,7 @@ if [ "$PLATFORM" == "Darwin" ]; then
   tar -czf "$GZIP_FILE" -C $DESTINATION .
   tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
 elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  echo "Using tar and 7z here because tar is unable to access lzma compression on Windows"
   tar -caf "$GZIP_FILE" -C $DESTINATION .
   # hacking around the fact that 7z refuses to write to LZMA files despite them
   # being the native format of 7z files

--- a/test/macos.sh
+++ b/test/macos.sh
@@ -1,43 +1,88 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT="$DIR/.."
+GIT_LFS_VERSION=2.6.0
+TARGET_PLATFORM=macOS
+GIT_LFS_CHECKSUM=42bf89b9775a69ab7dbe65847e174fe802d54ce6ed0d553bd497c740f2803f60
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$CURRENT_DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_VERSION=2.5.2 \
-TARGET_PLATFORM=macOS \
-GIT_LFS_CHECKSUM=eedb80c79f1d3106aa5f1496ddc505e1c1c86c290293d81fb20c5358c615fd74 \
 . "$ROOT/script/build-macos.sh" $SOURCE $DESTINATION
+
+source "$ROOT/script/compute-checksum.sh"
+
+VERSION=$(
+  cd $SOURCE || exit 1
+  VERSION=$(git describe --exact-match HEAD)
+  EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" == "128" ]; then
+    echo "Git commit does not have tag, cannot use version to build from"
+    exit 1
+  fi
+  echo "$VERSION"
+)
 
 echo "Archive contents:"
 cd $DESTINATION
 du -ah $DESTINATION
 cd - > /dev/null
 
-GZIP_FILE="dugite-native-$VERSION-macos-test.tar.gz"
-LZMA_FILE="dugite-native-$VERSION-macos-test.lzma"
+BUILD_HASH=$(git rev-parse --short HEAD)
 
+if ! [ -d "$DESTINATION" ]; then
+  echo "No output found, exiting..."
+  exit 1
+fi
+
+if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.lzma"
+elif [ "$TARGET_PLATFORM" == "macOS" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.lzma"
+elif [ "$TARGET_PLATFORM" == "win32" ]; then
+  if [ "$WIN_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="x86"; fi
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.lzma"
+elif [ "$TARGET_PLATFORM" == "arm64" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.lzma"
+else
+  echo "Unable to package Git for platform $TARGET_PLATFORM"
+  exit 1
+fi
+
+(
 echo ""
-echo "Creating archives..."
-if [ "$(uname -s)" == "Darwin" ]; then
-  tar -czf $GZIP_FILE -C $DESTINATION .
-  tar --lzma -cf $LZMA_FILE -C $DESTINATION .
+PLATFORM=$(uname -s)
+echo "Creating archives for $PLATFORM (${OSTYPE})..."
+mkdir output
+cd output || exit 1
+if [ "$PLATFORM" == "Darwin" ]; then
+  echo "Using bsdtar which has some different command flags"
+  tar -czf "$GZIP_FILE" -C $DESTINATION .
+  tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
+elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
+  # hacking around the fact that 7z refuses to write to LZMA files despite them
+  # being the native format of 7z files
+  NEW_LZMA_FILE="dugite-native-$VERSION-win32-test.7z"
+  7z u -t7z "$NEW_LZMA_FILE" $DESTINATION/*
+  mv $NEW_LZMA_FILE $LZMA_FILE
 else
-  tar -caf $GZIP_FILE -C $DESTINATION .
-  tar -caf $LZMA_FILE -C $DESTINATION .
+  echo "Using unix tar by default"
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
+  tar -caf "$LZMA_FILE" -C $DESTINATION .
 fi
 
-if [ "$APPVEYOR" == "True" ]; then
-  GZIP_CHECKSUM=$(sha256sum $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(sha256sum $LZMA_FILE | awk '{print $1;}')
-else
-  GZIP_CHECKSUM=$(shasum -a 256 $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
-fi
+GZIP_CHECKSUM=$(compute_checksum "$GZIP_FILE")
+LZMA_CHECKSUM=$(compute_checksum "$LZMA_FILE")
 
-GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
-LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+GZIP_SIZE=$(du -h "$GZIP_FILE" | cut -f1)
+LZMA_SIZE=$(du -h "$LZMA_FILE" | cut -f1)
 
 echo "${GZIP_CHECKSUM}" | tr -d '\n' > "${GZIP_FILE}.sha256"
 echo "${LZMA_CHECKSUM}" | tr -d '\n' > "${LZMA_FILE}.sha256"
@@ -45,3 +90,4 @@ echo "${LZMA_CHECKSUM}" | tr -d '\n' > "${LZMA_FILE}.sha256"
 echo "Packages created:"
 echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"
 echo "${LZMA_FILE} - ${LZMA_SIZE} - checksum: ${LZMA_CHECKSUM}"
+)

--- a/test/macos.sh
+++ b/test/macos.sh
@@ -25,10 +25,11 @@ VERSION=$(
   echo "$VERSION"
 )
 
-echo "Archive contents:"
+(
+echo "Generated bits to package at $DESTINATION:"
 cd $DESTINATION
-du -ah $DESTINATION
-cd - > /dev/null
+find .
+)
 
 BUILD_HASH=$(git rev-parse --short HEAD)
 

--- a/test/ubuntu.sh
+++ b/test/ubuntu.sh
@@ -67,6 +67,7 @@ if [ "$PLATFORM" == "Darwin" ]; then
   tar -czf "$GZIP_FILE" -C $DESTINATION .
   tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
 elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  echo "Using tar and 7z here because tar is unable to access lzma compression on Windows"
   tar -caf "$GZIP_FILE" -C $DESTINATION .
   # hacking around the fact that 7z refuses to write to LZMA files despite them
   # being the native format of 7z files

--- a/test/ubuntu.sh
+++ b/test/ubuntu.sh
@@ -25,10 +25,11 @@ VERSION=$(
   echo "$VERSION"
 )
 
-echo "Archive contents:"
+(
+echo "Generated bits to package at $DESTINATION:"
 cd $DESTINATION
-du -ah $DESTINATION
-cd - > /dev/null
+find .
+)
 
 BUILD_HASH=$(git rev-parse --short HEAD)
 

--- a/test/ubuntu.sh
+++ b/test/ubuntu.sh
@@ -1,43 +1,88 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT="$DIR/.."
+GIT_LFS_VERSION=2.6.0
+TARGET_PLATFORM=ubuntu
+GIT_LFS_CHECKSUM=43e9311bdded82d43c574b075aafaf56681a3450c1ccf59cce9d362acabf1362
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$CURRENT_DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_VERSION=2.5.2 \
-TARGET_PLATFORM=ubuntu \
-GIT_LFS_CHECKSUM=624396e8994578ac38c3e5987889be56dba453c378c0675d56cffbc5b8972aa5 \
 . "$ROOT/script/build-ubuntu.sh" $SOURCE $DESTINATION
+
+source "$ROOT/script/compute-checksum.sh"
+
+VERSION=$(
+  cd $SOURCE || exit 1
+  VERSION=$(git describe --exact-match HEAD)
+  EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" == "128" ]; then
+    echo "Git commit does not have tag, cannot use version to build from"
+    exit 1
+  fi
+  echo "$VERSION"
+)
 
 echo "Archive contents:"
 cd $DESTINATION
 du -ah $DESTINATION
 cd - > /dev/null
 
-GZIP_FILE="dugite-native-$VERSION-ubuntu-test.tar.gz"
-LZMA_FILE="dugite-native-$VERSION-ubuntu-test.lzma"
+BUILD_HASH=$(git rev-parse --short HEAD)
 
+if ! [ -d "$DESTINATION" ]; then
+  echo "No output found, exiting..."
+  exit 1
+fi
+
+if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.lzma"
+elif [ "$TARGET_PLATFORM" == "macOS" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.lzma"
+elif [ "$TARGET_PLATFORM" == "win32" ]; then
+  if [ "$WIN_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="x86"; fi
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.lzma"
+elif [ "$TARGET_PLATFORM" == "arm64" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.lzma"
+else
+  echo "Unable to package Git for platform $TARGET_PLATFORM"
+  exit 1
+fi
+
+(
 echo ""
-echo "Creating archives..."
-if [ "$(uname -s)" == "Darwin" ]; then
-  tar -czf $GZIP_FILE -C $DESTINATION .
-  tar --lzma -cf $LZMA_FILE -C $DESTINATION .
+PLATFORM=$(uname -s)
+echo "Creating archives for $PLATFORM (${OSTYPE})..."
+mkdir output
+cd output || exit 1
+if [ "$PLATFORM" == "Darwin" ]; then
+  echo "Using bsdtar which has some different command flags"
+  tar -czf "$GZIP_FILE" -C $DESTINATION .
+  tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
+elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
+  # hacking around the fact that 7z refuses to write to LZMA files despite them
+  # being the native format of 7z files
+  NEW_LZMA_FILE="dugite-native-$VERSION-win32-test.7z"
+  7z u -t7z "$NEW_LZMA_FILE" $DESTINATION/*
+  mv $NEW_LZMA_FILE $LZMA_FILE
 else
-  tar -caf $GZIP_FILE -C $DESTINATION .
-  tar -caf $LZMA_FILE -C $DESTINATION .
+  echo "Using unix tar by default"
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
+  tar -caf "$LZMA_FILE" -C $DESTINATION .
 fi
 
-if [ "$APPVEYOR" == "True" ]; then
-  GZIP_CHECKSUM=$(sha256sum $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(sha256sum $LZMA_FILE | awk '{print $1;}')
-else
-  GZIP_CHECKSUM=$(shasum -a 256 $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
-fi
+GZIP_CHECKSUM=$(compute_checksum "$GZIP_FILE")
+LZMA_CHECKSUM=$(compute_checksum "$LZMA_FILE")
 
-GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
-LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+GZIP_SIZE=$(du -h "$GZIP_FILE" | cut -f1)
+LZMA_SIZE=$(du -h "$LZMA_FILE" | cut -f1)
 
 echo "${GZIP_CHECKSUM}" | tr -d '\n' > "${GZIP_FILE}.sha256"
 echo "${LZMA_CHECKSUM}" | tr -d '\n' > "${LZMA_FILE}.sha256"
@@ -45,3 +90,4 @@ echo "${LZMA_CHECKSUM}" | tr -d '\n' > "${LZMA_FILE}.sha256"
 echo "Packages created:"
 echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"
 echo "${LZMA_FILE} - ${LZMA_SIZE} - checksum: ${LZMA_CHECKSUM}"
+)

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -28,10 +28,11 @@ VERSION=$(
   echo "$VERSION"
 )
 
-echo "Archive contents:"
+(
+echo "Generated bits to package at $DESTINATION:"
 cd $DESTINATION
-du -ah $DESTINATION
-cd - > /dev/null
+find .
+)
 
 BUILD_HASH=$(git rev-parse --short HEAD)
 

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -70,6 +70,7 @@ if [ "$PLATFORM" == "Darwin" ]; then
   tar -czf "$GZIP_FILE" -C $DESTINATION .
   tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
 elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  echo "Using tar and 7z here because tar is unable to access lzma compression on Windows"
   tar -caf "$GZIP_FILE" -C $DESTINATION .
   # hacking around the fact that 7z refuses to write to LZMA files despite them
   # being the native format of 7z files

--- a/test/win32.sh
+++ b/test/win32.sh
@@ -1,46 +1,91 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT="$DIR/.."
+GIT_LFS_VERSION=2.6.0
+TARGET_PLATFORM=win32
+WIN_ARCH=32
+GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip
+GIT_FOR_WINDOWS_CHECKSUM=9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922
+GIT_LFS_CHECKSUM=7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$CURRENT_DIR/.."
 SOURCE="$ROOT/git"
 DESTINATION="$ROOT/build/git"
 
-GIT_LFS_VERSION=2.5.2 \
-TARGET_PLATFORM=win32 \
-WIN_ARCH=32 \
-GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip \
-GIT_FOR_WINDOWS_CHECKSUM=9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922 \
-GIT_LFS_CHECKSUM=6cf7d4c169a17dd5b326f903708829e7471368b7e1235ab150ce77555f47b213 \
 . "$ROOT/script/build-win32.sh" $SOURCE $DESTINATION
+
+source "$ROOT/script/compute-checksum.sh"
+
+VERSION=$(
+  cd $SOURCE || exit 1
+  VERSION=$(git describe --exact-match HEAD)
+  EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" == "128" ]; then
+    echo "Git commit does not have tag, cannot use version to build from"
+    exit 1
+  fi
+  echo "$VERSION"
+)
 
 echo "Archive contents:"
 cd $DESTINATION
 du -ah $DESTINATION
 cd - > /dev/null
 
-GZIP_FILE="dugite-native-$VERSION-win32-test.tar.gz"
-LZMA_FILE="dugite-native-$VERSION-win32-test.lzma"
+BUILD_HASH=$(git rev-parse --short HEAD)
 
+if ! [ -d "$DESTINATION" ]; then
+  echo "No output found, exiting..."
+  exit 1
+fi
+
+if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.lzma"
+elif [ "$TARGET_PLATFORM" == "macOS" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.lzma"
+elif [ "$TARGET_PLATFORM" == "win32" ]; then
+  if [ "$WIN_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="x86"; fi
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.lzma"
+elif [ "$TARGET_PLATFORM" == "arm64" ]; then
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-arm64.lzma"
+else
+  echo "Unable to package Git for platform $TARGET_PLATFORM"
+  exit 1
+fi
+
+(
 echo ""
-echo "Creating archives..."
-if [ "$(uname -s)" == "Darwin" ]; then
-  tar -czf $GZIP_FILE -C $DESTINATION .
-  tar --lzma -cf $LZMA_FILE -C $DESTINATION .
+PLATFORM=$(uname -s)
+echo "Creating archives for $PLATFORM (${OSTYPE})..."
+mkdir output
+cd output || exit 1
+if [ "$PLATFORM" == "Darwin" ]; then
+  echo "Using bsdtar which has some different command flags"
+  tar -czf "$GZIP_FILE" -C $DESTINATION .
+  tar --lzma -cf "$LZMA_FILE" -C $DESTINATION .
+elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
+  # hacking around the fact that 7z refuses to write to LZMA files despite them
+  # being the native format of 7z files
+  NEW_LZMA_FILE="dugite-native-$VERSION-win32-test.7z"
+  7z u -t7z "$NEW_LZMA_FILE" $DESTINATION/*
+  mv $NEW_LZMA_FILE $LZMA_FILE
 else
-  tar -caf $GZIP_FILE -C $DESTINATION .
-  tar -caf $LZMA_FILE -C $DESTINATION .
+  echo "Using unix tar by default"
+  tar -caf "$GZIP_FILE" -C $DESTINATION .
+  tar -caf "$LZMA_FILE" -C $DESTINATION .
 fi
 
-if [ "$APPVEYOR" == "True" ]; then
-  GZIP_CHECKSUM=$(sha256sum $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(sha256sum $LZMA_FILE | awk '{print $1;}')
-else
-  GZIP_CHECKSUM=$(shasum -a 256 $GZIP_FILE | awk '{print $1;}')
-  LZMA_CHECKSUM=$(shasum -a 256 $LZMA_FILE | awk '{print $1;}')
-fi
+GZIP_CHECKSUM=$(compute_checksum "$GZIP_FILE")
+LZMA_CHECKSUM=$(compute_checksum "$LZMA_FILE")
 
-GZIP_SIZE=$(du -h $GZIP_FILE | cut -f1)
-LZMA_SIZE=$(du -h $LZMA_FILE | cut -f1)
+GZIP_SIZE=$(du -h "$GZIP_FILE" | cut -f1)
+LZMA_SIZE=$(du -h "$LZMA_FILE" | cut -f1)
 
 echo "${GZIP_CHECKSUM}" | tr -d '\n' > "${GZIP_FILE}.sha256"
 echo "${LZMA_CHECKSUM}" | tr -d '\n' > "${LZMA_FILE}.sha256"
@@ -48,3 +93,4 @@ echo "${LZMA_CHECKSUM}" | tr -d '\n' > "${LZMA_FILE}.sha256"
 echo "Packages created:"
 echo "${GZIP_FILE} - ${GZIP_SIZE} - checksum: ${GZIP_CHECKSUM}"
 echo "${LZMA_FILE} - ${LZMA_SIZE} - checksum: ${LZMA_CHECKSUM}"
+)


### PR DESCRIPTION
Appveyor currently quietly fails when running `script/package.sh` because the version of `tar` it has there cannot access `lzma`. Here's an example build: https://ci.appveyor.com/project/github-windows/dugite-native/builds/20038933

```
Creating archives...
/bin/sh: lzma: command not found
tar: dugite-native-v2.19.1-cef2e3b-windows-x64.lzma: Cannot write: Broken pipe
tar: Child returned status 127
tar: Error is not recoverable: exiting now
Packages created:
dugite-native-v2.19.1-cef2e3b-windows-x64.tar.gz - 24M - checksum: 2505622addfa0b32dedf7e6b5dfd900f84a143c1e15fae423d2ff1422405680b
dugite-native-v2.19.1-cef2e3b-windows-x64.lzma - 0 - checksum: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

This PR changes the support for running scripts under a Windows host:

 - [x] correctly fail because of the lack of `lzma`
 - [x] switch over to `7z` interface to generate `lzma` archive
- [x] verify directory structure when unpacking