### PR TITLE
use dependencies to generate build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 sudo: required
-
 services:
   - docker
-
 env:
   global:
     - GIT_LFS_VERSION=2.6.0
-
 matrix:
   include:
     - os: linux
@@ -14,13 +11,11 @@ matrix:
       env:
         - TARGET_PLATFORM=ubuntu
         - GIT_LFS_CHECKSUM=43e9311bdded82d43c574b075aafaf56681a3450c1ccf59cce9d362acabf1362
-
     - os: osx
       language: c
       env:
         - TARGET_PLATFORM=macOS
         - GIT_LFS_CHECKSUM=42bf89b9775a69ab7dbe65847e174fe802d54ce6ed0d553bd497c740f2803f60
-
     - os: linux
       language: c
       env:
@@ -29,7 +24,6 @@ matrix:
         - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip
         - GIT_FOR_WINDOWS_CHECKSUM=f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3
         - GIT_LFS_CHECKSUM=f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279
-
     - os: linux
       language: c
       env:
@@ -38,29 +32,23 @@ matrix:
         - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip
         - GIT_FOR_WINDOWS_CHECKSUM=9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922
         - GIT_LFS_CHECKSUM=7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5
-
     - os: linux
       language: c
       env:
         - TARGET_PLATFORM=arm64
         - GIT_LFS_CHECKSUM=574192d485ce84495fe3f228a57e3ef80f93635ae4677ac4a189425b4c9aeb0a
-
     - os: linux
       language: shell
       script:
         - bash -c 'shopt -s globstar; shellcheck script/**/*.sh'
-
 compiler:
   - gcc
-
 script:
   - script/build.sh && script/package.sh
-
 branches:
   only:
     - master
     - /^v[0-9]*.[0-9]*.[0.9]*.*$/
-
 deploy:
   provider: releases
   api_key: $GITHUB_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+# NOTE:
+#
+# This config file is generated from a source script and should not be modified
+# manually. If you want to make changes to this config that are remembered
+# between upgrades, ensure that you update `script/generate-travis-config.js`,
+# run `npm run generate-travis-config` to generate a new config, and commit the
+# change to the repository.
+#
 sudo: required
 services:
   - docker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,11 @@
+# NOTE:
+#
+# This config file is generated from a source script and should not be modified
+# manually. If you want to make changes to this config that are remembered
+# between upgrades, ensure that you update `script/generate-appveyor-config.js`,
+# run `npm run generate-appveyor-config` to generate a new config, and commit
+# the change to the repository.
+#
 image: Visual Studio 2015
 skip_branch_with_pr: true
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,20 @@
 image: Visual Studio 2015
-
-# Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
-
 environment:
-  TARGET_PLATFORM: win32
-  WIN_ARCH: 64
-  GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip
-  GIT_FOR_WINDOWS_CHECKSUM: f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3
   GIT_LFS_VERSION: 2.6.0
-  GIT_LFS_CHECKSUM: f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279
-
+  matrix:
+    - TARGET_PLATFORM: win32
+      WIN_ARCH: 64
+      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip
+      GIT_FOR_WINDOWS_CHECKSUM: f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3
+      GIT_LFS_CHECKSUM: f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279
+    - TARGET_PLATFORM: win32
+      WIN_ARCH: 32
+      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip
+      GIT_FOR_WINDOWS_CHECKSUM: 9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922
+      GIT_LFS_CHECKSUM: 7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5
 build_script:
-  - cmd: git submodule update --init --recursive
-  - bash script\build.sh
-  - bash script\package.sh
-
+  - 'cmd: git submodule update --init --recursive'
+  - "bash: script\\build.sh"
+  - "bash: script\\package.sh"
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
       GIT_FOR_WINDOWS_CHECKSUM: 9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922
       GIT_LFS_CHECKSUM: 7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5
 build_script:
-  - 'cmd: git submodule update --init --recursive'
-  - "bash: script\\build.sh"
-  - "bash: script\\package.sh"
+  - git submodule update --init --recursive
+  - bash script\build.sh
+  - bash script\package.sh
 test: off

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,77 +1,77 @@
 {
-    "git": {
-        "version": "v2.19.1",
-        "packages": [
-            {
-                "platform": "windows",
-                "arch": "amd64",
-                "url": "https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip",
-                "checksum": "f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3"
-            },
-            {
-                "platform": "windows",
-                "arch": "x86",
-                "url": "https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip",
-                "checksum": "9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922"
-            }
-        ]
-    },
-    "git-lfs": {
-        "version": "v2.6.0",
-        "files": [
-            {
-                "platform": "linux",
-                "arch": "amd64",
-                "name": "git-lfs-linux-amd64-v2.6.0.tar.gz",
-                "checksum": "43e9311bdded82d43c574b075aafaf56681a3450c1ccf59cce9d362acabf1362"
-            },
-            {
-                "platform": "linux",
-                "arch": "arm64",
-                "name": "git-lfs-linux-arm64-v2.6.0.tar.gz",
-                "checksum": "574192d485ce84495fe3f228a57e3ef80f93635ae4677ac4a189425b4c9aeb0a"
-            },
-            {
-                "platform": "darwin",
-                "arch": "amd64",
-                "name": "git-lfs-darwin-amd64-v2.6.0.tar.gz",
-                "checksum": "42bf89b9775a69ab7dbe65847e174fe802d54ce6ed0d553bd497c740f2803f60"
-            },
-            {
-                "platform": "windows",
-                "arch": "amd64",
-                "name": "git-lfs-windows-amd64-v2.6.0.zip",
-                "checksum": "f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279"
-            },
-            {
-                "platform": "windows",
-                "arch": "x86",
-                "name": "git-lfs-windows-x86-v2.6.0.zip",
-                "checksum": "7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5"
-            }
-        ]
-    },
-    "smimesign": {
-        "version": "0.0.6",
-        "files": [
-            {
-                "platform": "darwin",
-                "arch": "amd64",
-                "name": "smimesign-0.0.6-macos.tgz",
-                "checksum": "771790f685176b132cb287302a9374120184f7f7973038a0232efee145781906"
-            },
-            {
-                "platform": "windows",
-                "arch": "amd64",
-                "name": "smimesign-windows-amd64-0.0.6.zip",
-                "checksum": "2a2f946e31f2d74eadcdcd97b7bfc69298cee2f11cf7cb03c604d28fa1b34cd3"
-            },
-            {
-                "platform": "windows",
-                "arch": "x86",
-                "name": "smimesign-windows-386-0.0.6.zip",
-                "checksum": "9a13d00aa02c0a5d277c030297d09f10a467f31e6740f1520a08e09a23046323"
-            }
-        ]
-    }
+  "git": {
+    "version": "v2.19.1",
+    "packages": [
+      {
+        "platform": "windows",
+        "arch": "amd64",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip",
+        "checksum": "f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3"
+      },
+      {
+        "platform": "windows",
+        "arch": "x86",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip",
+        "checksum": "9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922"
+      }
+    ]
+  },
+  "git-lfs": {
+    "version": "v2.6.0",
+    "files": [
+      {
+        "platform": "linux",
+        "arch": "amd64",
+        "name": "git-lfs-linux-amd64-v2.6.0.tar.gz",
+        "checksum": "43e9311bdded82d43c574b075aafaf56681a3450c1ccf59cce9d362acabf1362"
+      },
+      {
+        "platform": "linux",
+        "arch": "arm64",
+        "name": "git-lfs-linux-arm64-v2.6.0.tar.gz",
+        "checksum": "574192d485ce84495fe3f228a57e3ef80f93635ae4677ac4a189425b4c9aeb0a"
+      },
+      {
+        "platform": "darwin",
+        "arch": "amd64",
+        "name": "git-lfs-darwin-amd64-v2.6.0.tar.gz",
+        "checksum": "42bf89b9775a69ab7dbe65847e174fe802d54ce6ed0d553bd497c740f2803f60"
+      },
+      {
+        "platform": "windows",
+        "arch": "amd64",
+        "name": "git-lfs-windows-amd64-v2.6.0.zip",
+        "checksum": "f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279"
+      },
+      {
+        "platform": "windows",
+        "arch": "x86",
+        "name": "git-lfs-windows-x86-v2.6.0.zip",
+        "checksum": "7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5"
+      }
+    ]
+  },
+  "smimesign": {
+    "version": "0.0.6",
+    "files": [
+      {
+        "platform": "darwin",
+        "arch": "amd64",
+        "name": "smimesign-0.0.6-macos.tgz",
+        "checksum": "771790f685176b132cb287302a9374120184f7f7973038a0232efee145781906"
+      },
+      {
+        "platform": "windows",
+        "arch": "amd64",
+        "name": "smimesign-windows-amd64-0.0.6.zip",
+        "checksum": "2a2f946e31f2d74eadcdcd97b7bfc69298cee2f11cf7cb03c604d28fa1b34cd3"
+      },
+      {
+        "platform": "windows",
+        "arch": "x86",
+        "name": "smimesign-windows-386-0.0.6.zip",
+        "checksum": "9a13d00aa02c0a5d277c030297d09f10a467f31e6740f1520a08e09a23046323"
+      }
+    ]
+  }
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,71 @@
+{
+    "git": {
+        "version": "v2.19.1",
+        "packages": [
+            {
+                "platform": "windows",
+                "arch": "amd64",
+                "url": "https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip",
+                "checksum": "f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3"
+            },
+            {
+                "platform": "windows",
+                "arch": "x86",
+                "url": "https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip",
+                "checksum": "9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922"
+            }
+        ]
+    },
+    "git-lfs": {
+        "version": "v2.6.0",
+        "files": [
+            {
+                "platform": "linux",
+                "arch": "amd64",
+                "name": "git-lfs-linux-amd64-v2.6.0.tar.gz",
+                "checksum": "43e9311bdded82d43c574b075aafaf56681a3450c1ccf59cce9d362acabf1362"
+            },
+            {
+                "platform": "darwin",
+                "arch": "amd64",
+                "name": "git-lfs-darwin-amd64-v2.6.0.tar.gz",
+                "checksum": "42bf89b9775a69ab7dbe65847e174fe802d54ce6ed0d553bd497c740f2803f60"
+            },
+            {
+                "platform": "windows",
+                "arch": "amd64",
+                "name": "git-lfs-windows-amd64-v2.6.0.zip",
+                "checksum": "f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279"
+            },
+            {
+                "platform": "windows",
+                "arch": "x86",
+                "name": "git-lfs-windows-x86-v2.6.0.zip",
+                "checksum": "7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5"
+            }
+        ]
+    },
+    "smimesign": {
+        "version": "0.0.6",
+        "files": [
+            {
+                "platform": "darwin",
+                "arch": "amd64",
+                "name": "smimesign-0.0.6-macos.tgz",
+                "checksum": "771790f685176b132cb287302a9374120184f7f7973038a0232efee145781906"
+            },
+            {
+                "platform": "windows",
+                "arch": "amd64",
+                "name": "smimesign-windows-amd64-0.0.6.zip",
+                "checksum": "2a2f946e31f2d74eadcdcd97b7bfc69298cee2f11cf7cb03c604d28fa1b34cd3"
+            },
+            {
+                "platform": "windows",
+                "arch": "x86",
+                "name": "smimesign-windows-386-0.0.6.zip",
+                "checksum": "9a13d00aa02c0a5d277c030297d09f10a467f31e6740f1520a08e09a23046323"
+            }
+        ]
+    }
+}

--- a/dependencies.json
+++ b/dependencies.json
@@ -26,6 +26,12 @@
                 "checksum": "43e9311bdded82d43c574b075aafaf56681a3450c1ccf59cce9d362acabf1362"
             },
             {
+                "platform": "linux",
+                "arch": "arm64",
+                "name": "git-lfs-linux-arm64-v2.6.0.tar.gz",
+                "checksum": "574192d485ce84495fe3f228a57e3ef80f93635ae4677ac4a189425b4c9aeb0a"
+            },
+            {
                 "platform": "darwin",
                 "arch": "amd64",
                 "name": "git-lfs-darwin-amd64-v2.6.0.tar.gz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,15 +41,6 @@
         "json-schema-traverse": "^0.3.0"
       }
     },
-    "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -188,12 +179,6 @@
         "es6-promise": "^4.0.3"
       }
     },
-    "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -331,16 +316,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -377,12 +352,6 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
-    },
-    "junk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-2.1.0.tgz",
-      "integrity": "sha1-9DG0t/By3FAKXxDOf07HGTDnATQ=",
-      "dev": true
     },
     "lodash": {
       "version": "4.17.11",
@@ -423,18 +392,6 @@
       "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
       "dev": true
     },
-    "node-yaml": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-yaml/-/node-yaml-3.1.1.tgz",
-      "integrity": "sha512-gjPv+9gUi79GqsLRWACzIIZdGJBUVHm8CDT2QFMNtK2Oge1hWdRneYt/+F7ViKvoqniMwa4BhvhYbn0J4BdiIg==",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "js-yaml": "3.9.1",
-        "junk": "2.1.0",
-        "promise-fs": "1.2.3"
-      }
-    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -457,42 +414,11 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
     "prettier": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.2.tgz",
       "integrity": "sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==",
       "dev": true
-    },
-    "promise-fs": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/promise-fs/-/promise-fs-1.2.3.tgz",
-      "integrity": "sha1-QCQQ+S7djDl47lVSNp8cW+vM/CI=",
-      "dev": true,
-      "requires": {
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
     },
     "psl": {
       "version": "1.1.29",
@@ -577,12 +503,6 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
@@ -674,6 +594,12 @@
       "requires": {
         "semver": "^5.0.1"
       }
+    },
+    "yaml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.0.1.tgz",
+      "integrity": "sha512-ysU56qumPH0tEML2hiFVAo+rCnG/0+oO2Ye3fN4c40GBN7kX1fYhDqSoX7OohimcI/Xkkr1DdaUlg5+afinRqA==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "generate-release-notes": "node script/generate-release-notes.js",
     "prettier": "prettier -l **/*.y{,a}ml **/*.{js,ts}",
     "prettier-fix": "prettier --write **/*.y{,a}ml **/*.{js,ts}",
-    "generate-appveyor-config": "node script/generate-appveyor-config.js"
+    "generate-appveyor-config": "node script/generate-appveyor-config.js",
+    "generate-all-config": "npm run generate-appveyor-config"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "update-test-harness": "node script/update-test-harness.js",
     "generate-release-notes": "node script/generate-release-notes.js",
     "prettier": "prettier -l **/*.y{,a}ml **/*.{js,ts}",
-    "prettier-fix": "prettier --write **/*.y{,a}ml **/*.{js,ts}"
+    "prettier-fix": "prettier --write **/*.y{,a}ml **/*.{js,ts}",
+    "generate-appveyor-config": "node script/generate-appveyor-config.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "generate-release-notes": "node script/generate-release-notes.js",
     "prettier": "prettier -l **/*.y{,a}ml **/*.{js,ts}",
     "prettier-fix": "prettier --write **/*.y{,a}ml **/*.{js,ts}",
-    "generate-all-config": "npm run generate-appveyor-config && npm run generate-travis-config",
+    "generate-all-config": "npm run generate-appveyor-config && npm run generate-travis-config && npm run prettier-fix",
     "generate-appveyor-config": "node script/generate-appveyor-config.js",
     "generate-travis-config": "node script/generate-travis-config.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "update-test-harness": "node script/update-test-harness.js",
     "generate-release-notes": "node script/generate-release-notes.js",
-    "prettier": "prettier -l **/*.y{,a}ml **/*.{js,ts}",
-    "prettier-fix": "prettier --write **/*.y{,a}ml **/*.{js,ts}",
+    "prettier": "prettier -l **/*.y{,a}ml **/*.{js,ts,json}",
+    "prettier-fix": "prettier --write **/*.y{,a}ml **/*.{js,ts,json}",
     "generate-all-config": "npm run generate-appveyor-config && npm run generate-travis-config && npm run prettier-fix",
     "generate-appveyor-config": "node script/generate-appveyor-config.js",
     "generate-travis-config": "node script/generate-travis-config.js"

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "homepage": "https://github.com/desktop/dugite-native#readme",
   "devDependencies": {
     "@octokit/rest": "^15.12.0",
-    "node-yaml": "^3.1.1",
     "prettier": "^1.15.2",
     "request": "^2.88.0",
-    "request-promise": "^4.2.2"
+    "request-promise": "^4.2.2",
+    "yaml": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "generate-release-notes": "node script/generate-release-notes.js",
     "prettier": "prettier -l **/*.y{,a}ml **/*.{js,ts}",
     "prettier-fix": "prettier --write **/*.y{,a}ml **/*.{js,ts}",
+    "generate-all-config": "npm run generate-appveyor-config && npm run generate-travis-config",
     "generate-appveyor-config": "node script/generate-appveyor-config.js",
-    "generate-all-config": "npm run generate-appveyor-config"
+    "generate-travis-config": "node script/generate-travis-config.js"
   },
   "repository": {
     "type": "git",

--- a/script/generate-appveyor-config.js
+++ b/script/generate-appveyor-config.js
@@ -2,17 +2,32 @@ const fs = require('fs')
 const path = require('path')
 const YAML = require('yaml')
 
+// TODO: read Windows configs from dependencies.json and use those values
+//       rather than the current placeholders
+
 const baseConfig = {
     'image': 'Visual Studio 2015',
 
     'skip_branch_with_pr': true,
     'environment': {
-        'TARGET_PLATFORM': 'win32',
-        'WIN_ARCH': 64,
-        'GIT_FOR_WINDOWS_URL': 'https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip',
-        'GIT_FOR_WINDOWS_CHECKSUM': 'f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3',
         'GIT_LFS_VERSION': '2.6.0',
-        'GIT_LFS_CHECKSUM': 'f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279'
+        'matrix': [
+            {
+                'TARGET_PLATFORM': 'win32',
+                'WIN_ARCH': 64,
+                'GIT_FOR_WINDOWS_URL': 'https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip',
+                'GIT_FOR_WINDOWS_CHECKSUM': 'f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3',
+                'GIT_LFS_CHECKSUM': 'f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279'
+            },
+            {
+                'TARGET_PLATFORM': 'win32',
+                'WIN_ARCH': 32,
+                'GIT_FOR_WINDOWS_URL': 'https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip',
+                'GIT_FOR_WINDOWS_CHECKSUM': '9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922',
+                'GIT_LFS_CHECKSUM': '7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5'
+            }
+        ]
+
     },
     'build_script': [
         'cmd: git submodule update --init --recursive',

--- a/script/generate-appveyor-config.js
+++ b/script/generate-appveyor-config.js
@@ -72,4 +72,7 @@ const appveyorFile = path.resolve(__dirname, '..', 'appveyor.yml')
 
 const yaml = YAML.stringify(baseConfig)
 
+// TODO: insert comment lines before file to indicate this is a generated
+//       file and that you should update this script and then run `npm run generate-all-config`
+
 fs.writeFileSync(appveyorFile, yaml)

--- a/script/generate-appveyor-config.js
+++ b/script/generate-appveyor-config.js
@@ -2,32 +2,63 @@ const fs = require('fs')
 const path = require('path')
 const YAML = require('yaml')
 
-// TODO: read Windows configs from dependencies.json and use those values
-//       rather than the current placeholders
+const dependencies = require('../dependencies.json')
+
+function getLFSVersion() {
+    const lfs = dependencies['git-lfs']
+    const fullVersion = lfs.version
+    // trim the leading `v` from the version number
+    return fullVersion.replace('v', '')
+}
+
+function getConfig(platform, arch) {
+    if (platform !== 'windows') {
+        throw new Error(`Unsupported platform '${platform}'`)
+    }
+
+    const git = dependencies['git']
+    const gitPackage = git.packages.find(f => f.platform === platform && f.arch === arch)
+    if (gitPackage == null) {
+        throw new Error(`No Git package found for platform ${platform} and arch ${arch}`)
+    }
+
+    const lfs = dependencies['git-lfs']
+    const lfsFile = lfs.files.find(f => f.platform === platform && f.arch === arch)
+    if (lfsFile == null) {
+        throw new Error(`No Git LFS file found for platform ${platform} and arch ${arch}`)
+    }
+
+    if (arch === 'amd64') {
+        return {
+            'TARGET_PLATFORM': 'win32',
+            'WIN_ARCH': 64,
+            'GIT_FOR_WINDOWS_URL': gitPackage.url,
+            'GIT_FOR_WINDOWS_CHECKSUM': gitPackage.checksum,
+            'GIT_LFS_CHECKSUM': lfsFile.checksum
+        }
+    } else if (arch === 'x86') {
+        return {
+            'TARGET_PLATFORM': 'win32',
+            'WIN_ARCH': 32,
+            'GIT_FOR_WINDOWS_URL': gitPackage.url,
+            'GIT_FOR_WINDOWS_CHECKSUM': gitPackage.checksum,
+            'GIT_LFS_CHECKSUM': lfsFile.checksum
+        }
+    } else {
+        throw new Error(`Unsupported architecture '${arch}'`)
+    }
+}
 
 const baseConfig = {
     'image': 'Visual Studio 2015',
 
     'skip_branch_with_pr': true,
     'environment': {
-        'GIT_LFS_VERSION': '2.6.0',
+        'GIT_LFS_VERSION': getLFSVersion(),
         'matrix': [
-            {
-                'TARGET_PLATFORM': 'win32',
-                'WIN_ARCH': 64,
-                'GIT_FOR_WINDOWS_URL': 'https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip',
-                'GIT_FOR_WINDOWS_CHECKSUM': 'f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3',
-                'GIT_LFS_CHECKSUM': 'f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279'
-            },
-            {
-                'TARGET_PLATFORM': 'win32',
-                'WIN_ARCH': 32,
-                'GIT_FOR_WINDOWS_URL': 'https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-32-bit.zip',
-                'GIT_FOR_WINDOWS_CHECKSUM': '9bde728fe03f66a022b3e41408902ccfceb56a34067db1f35d6509375b9be922',
-                'GIT_LFS_CHECKSUM': '7fa3475c60221837860138b4fd0fd0ad1213a5e49c596fdb0aac8932ca7a20a5'
-            }
+            getConfig('windows', 'amd64'),
+            getConfig('windows', 'x86')
         ]
-
     },
     'build_script': [
         'cmd: git submodule update --init --recursive',

--- a/script/generate-appveyor-config.js
+++ b/script/generate-appveyor-config.js
@@ -1,0 +1,29 @@
+const fs = require('fs')
+const path = require('path')
+const YAML = require('yaml')
+
+const baseConfig = {
+    'image': 'Visual Studio 2015',
+
+    'skip_branch_with_pr': true,
+    'environment': {
+        'TARGET_PLATFORM': 'win32',
+        'WIN_ARCH': 64,
+        'GIT_FOR_WINDOWS_URL': 'https://github.com/git-for-windows/git/releases/download/v2.19.1.windows.1/MinGit-2.19.1-64-bit.zip',
+        'GIT_FOR_WINDOWS_CHECKSUM': 'f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3',
+        'GIT_LFS_VERSION': '2.6.0',
+        'GIT_LFS_CHECKSUM': 'f1312d00e435c16c8d19d914d5108db6a5ddbee1badb214c66f22cfa5d18b279'
+    },
+    'build_script': [
+        'cmd: git submodule update --init --recursive',
+        'bash: script\\build.sh',
+        'bash: script\\package.sh',
+    ],
+    'test': 'off'
+}
+
+const appveyorFile = path.resolve(__dirname, '..', 'appveyor.yml')
+
+const yaml = YAML.stringify(baseConfig)
+
+fs.writeFileSync(appveyorFile, yaml)

--- a/script/generate-appveyor-config.js
+++ b/script/generate-appveyor-config.js
@@ -77,7 +77,16 @@ const appveyorFile = path.resolve(__dirname, '..', 'appveyor.yml')
 
 const yaml = YAML.stringify(baseConfig)
 
-// TODO: insert comment lines before file to indicate this is a generated
-//       file and that you should update this script and then run `npm run generate-all-config`
+const commentPreamble = `# NOTE:
+#
+# This config file is generated from a source script and should not be modified
+# manually. If you want to make changes to this config that are remembered
+# between upgrades, ensure that you update \`script/generate-appveyor-config.js\`,
+# run \`npm run generate-appveyor-config\` to generate a new config, and commit
+# the change to the repository.
+#`
 
-fs.writeFileSync(appveyorFile, yaml)
+const fileContents = `${commentPreamble}
+${yaml}`
+
+fs.writeFileSync(appveyorFile, fileContents)

--- a/script/generate-appveyor-config.js
+++ b/script/generate-appveyor-config.js
@@ -5,67 +5,72 @@ const YAML = require('yaml')
 const dependencies = require('../dependencies.json')
 
 function getLFSVersion() {
-    const lfs = dependencies['git-lfs']
-    const fullVersion = lfs.version
-    // trim the leading `v` from the version number
-    return fullVersion.replace('v', '')
+  const lfs = dependencies['git-lfs']
+  const fullVersion = lfs.version
+  // trim the leading `v` from the version number
+  return fullVersion.replace('v', '')
 }
 
 function getConfig(platform, arch) {
-    if (platform !== 'windows') {
-        throw new Error(`Unsupported platform '${platform}'`)
-    }
+  if (platform !== 'windows') {
+    throw new Error(`Unsupported platform '${platform}'`)
+  }
 
-    const git = dependencies['git']
-    const gitPackage = git.packages.find(f => f.platform === platform && f.arch === arch)
-    if (gitPackage == null) {
-        throw new Error(`No Git package found for platform ${platform} and arch ${arch}`)
-    }
+  const git = dependencies['git']
+  const gitPackage = git.packages.find(
+    f => f.platform === platform && f.arch === arch
+  )
+  if (gitPackage == null) {
+    throw new Error(
+      `No Git package found for platform ${platform} and arch ${arch}`
+    )
+  }
 
-    const lfs = dependencies['git-lfs']
-    const lfsFile = lfs.files.find(f => f.platform === platform && f.arch === arch)
-    if (lfsFile == null) {
-        throw new Error(`No Git LFS file found for platform ${platform} and arch ${arch}`)
-    }
+  const lfs = dependencies['git-lfs']
+  const lfsFile = lfs.files.find(
+    f => f.platform === platform && f.arch === arch
+  )
+  if (lfsFile == null) {
+    throw new Error(
+      `No Git LFS file found for platform ${platform} and arch ${arch}`
+    )
+  }
 
-    if (arch === 'amd64') {
-        return {
-            'TARGET_PLATFORM': 'win32',
-            'WIN_ARCH': 64,
-            'GIT_FOR_WINDOWS_URL': gitPackage.url,
-            'GIT_FOR_WINDOWS_CHECKSUM': gitPackage.checksum,
-            'GIT_LFS_CHECKSUM': lfsFile.checksum
-        }
-    } else if (arch === 'x86') {
-        return {
-            'TARGET_PLATFORM': 'win32',
-            'WIN_ARCH': 32,
-            'GIT_FOR_WINDOWS_URL': gitPackage.url,
-            'GIT_FOR_WINDOWS_CHECKSUM': gitPackage.checksum,
-            'GIT_LFS_CHECKSUM': lfsFile.checksum
-        }
-    } else {
-        throw new Error(`Unsupported architecture '${arch}'`)
+  if (arch === 'amd64') {
+    return {
+      TARGET_PLATFORM: 'win32',
+      WIN_ARCH: 64,
+      GIT_FOR_WINDOWS_URL: gitPackage.url,
+      GIT_FOR_WINDOWS_CHECKSUM: gitPackage.checksum,
+      GIT_LFS_CHECKSUM: lfsFile.checksum,
     }
+  } else if (arch === 'x86') {
+    return {
+      TARGET_PLATFORM: 'win32',
+      WIN_ARCH: 32,
+      GIT_FOR_WINDOWS_URL: gitPackage.url,
+      GIT_FOR_WINDOWS_CHECKSUM: gitPackage.checksum,
+      GIT_LFS_CHECKSUM: lfsFile.checksum,
+    }
+  } else {
+    throw new Error(`Unsupported architecture '${arch}'`)
+  }
 }
 
 const baseConfig = {
-    'image': 'Visual Studio 2015',
+  image: 'Visual Studio 2015',
 
-    'skip_branch_with_pr': true,
-    'environment': {
-        'GIT_LFS_VERSION': getLFSVersion(),
-        'matrix': [
-            getConfig('windows', 'amd64'),
-            getConfig('windows', 'x86')
-        ]
-    },
-    'build_script': [
-        'cmd: git submodule update --init --recursive',
-        'bash: script\\build.sh',
-        'bash: script\\package.sh',
-    ],
-    'test': 'off'
+  skip_branch_with_pr: true,
+  environment: {
+    GIT_LFS_VERSION: getLFSVersion(),
+    matrix: [getConfig('windows', 'amd64'), getConfig('windows', 'x86')],
+  },
+  build_script: [
+    'cmd: git submodule update --init --recursive',
+    'bash: script\\build.sh',
+    'bash: script\\package.sh',
+  ],
+  test: 'off',
 }
 
 const appveyorFile = path.resolve(__dirname, '..', 'appveyor.yml')

--- a/script/generate-appveyor-config.js
+++ b/script/generate-appveyor-config.js
@@ -66,9 +66,9 @@ const baseConfig = {
     matrix: [getConfig('windows', 'amd64'), getConfig('windows', 'x86')],
   },
   build_script: [
-    'cmd: git submodule update --init --recursive',
-    'bash: script\\build.sh',
-    'bash: script\\package.sh',
+    'git submodule update --init --recursive',
+    'bash script\\build.sh',
+    'bash script\\package.sh',
   ],
   test: 'off',
 }

--- a/script/generate-travis-config.js
+++ b/script/generate-travis-config.js
@@ -5,143 +5,138 @@ const YAML = require('yaml')
 const dependencies = require('../dependencies.json')
 
 function getLFSVersion() {
-    const lfs = dependencies['git-lfs']
-    const fullVersion = lfs.version
-    // trim the leading `v` from the version number
-    return fullVersion.replace('v', '')
+  const lfs = dependencies['git-lfs']
+  const fullVersion = lfs.version
+  // trim the leading `v` from the version number
+  return fullVersion.replace('v', '')
 }
 
 function getConfig(platform, arch) {
+  const lfs = dependencies['git-lfs']
+  const lfsFile = lfs.files.find(
+    f => f.platform === platform && f.arch === arch
+  )
+  if (lfsFile == null) {
+    throw new Error(
+      `No Git LFS file found for platform ${platform} and arch ${arch}`
+    )
+  }
 
-    const lfs = dependencies['git-lfs']
-    const lfsFile = lfs.files.find(f => f.platform === platform && f.arch === arch)
-    if (lfsFile == null) {
-        throw new Error(`No Git LFS file found for platform ${platform} and arch ${arch}`)
+  if (platform === 'windows') {
+    const git = dependencies['git']
+    const gitPackage = git.packages.find(
+      f => f.platform === platform && f.arch === arch
+    )
+    if (gitPackage == null) {
+      throw new Error(
+        `No Git package found for platform ${platform} and arch ${arch}`
+      )
     }
 
-    if (platform === 'windows') {
-        const git = dependencies['git']
-        const gitPackage = git.packages.find(f => f.platform === platform && f.arch === arch)
-        if (gitPackage == null) {
-            throw new Error(`No Git package found for platform ${platform} and arch ${arch}`)
-        }
-
-        if (arch === 'amd64') {
-            return {
-                'os': 'linux',
-                'language': 'c',
-                'env': [
-                    'TARGET_PLATFORM=win32',
-                    'WIN_ARCH=64',
-                    `GIT_FOR_WINDOWS_URL=${gitPackage.url}`,
-                    `GIT_FOR_WINDOWS_CHECKSUM=${gitPackage.checksum}`,
-                    `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
-                ]
-            }
-        } else if (arch === 'x86') {
-            return {
-                'os': 'linux',
-                'language': 'c',
-                'env': [
-                    'TARGET_PLATFORM=win32',
-                    'WIN_ARCH=32',
-                    `GIT_FOR_WINDOWS_URL=${gitPackage.url}`,
-                    `GIT_FOR_WINDOWS_CHECKSUM=${gitPackage.checksum}`,
-                    `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
-                ]
-            }
-        } else {
-            throw new Error(`Unsupported platform '${platform}' and architecture '${arch}'`)
-        }
+    if (arch === 'amd64') {
+      return {
+        os: 'linux',
+        language: 'c',
+        env: [
+          'TARGET_PLATFORM=win32',
+          'WIN_ARCH=64',
+          `GIT_FOR_WINDOWS_URL=${gitPackage.url}`,
+          `GIT_FOR_WINDOWS_CHECKSUM=${gitPackage.checksum}`,
+          `GIT_LFS_CHECKSUM=${lfsFile.checksum}`,
+        ],
+      }
+    } else if (arch === 'x86') {
+      return {
+        os: 'linux',
+        language: 'c',
+        env: [
+          'TARGET_PLATFORM=win32',
+          'WIN_ARCH=32',
+          `GIT_FOR_WINDOWS_URL=${gitPackage.url}`,
+          `GIT_FOR_WINDOWS_CHECKSUM=${gitPackage.checksum}`,
+          `GIT_LFS_CHECKSUM=${lfsFile.checksum}`,
+        ],
+      }
+    } else {
+      throw new Error(
+        `Unsupported platform '${platform}' and architecture '${arch}'`
+      )
     }
+  }
 
-    if (platform === 'darwin' && arch === 'amd64') {
-        return {
-            'os': 'osx',
-            'language': 'c',
-            'env': [
-                'TARGET_PLATFORM=macOS',
-                `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
-            ]
-        }
+  if (platform === 'darwin' && arch === 'amd64') {
+    return {
+      os: 'osx',
+      language: 'c',
+      env: ['TARGET_PLATFORM=macOS', `GIT_LFS_CHECKSUM=${lfsFile.checksum}`],
     }
+  }
 
-    if (platform === 'linux') {
-        if (arch === 'amd64') {
-            return {
-                'os': 'linux',
-                'language': 'c',
-                'env': [
-                    'TARGET_PLATFORM=ubuntu',
-                    `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
-                ]
-            }
-        } else if (arch === 'arm64') {
-            return {
-                'os': 'linux',
-                'language': 'c',
-                'env': [
-                    'TARGET_PLATFORM=arm64',
-                    `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
-                ]
-            }
-        }
+  if (platform === 'linux') {
+    if (arch === 'amd64') {
+      return {
+        os: 'linux',
+        language: 'c',
+        env: ['TARGET_PLATFORM=ubuntu', `GIT_LFS_CHECKSUM=${lfsFile.checksum}`],
+      }
+    } else if (arch === 'arm64') {
+      return {
+        os: 'linux',
+        language: 'c',
+        env: ['TARGET_PLATFORM=arm64', `GIT_LFS_CHECKSUM=${lfsFile.checksum}`],
+      }
     }
+  }
 
-    throw new Error(`Unsupported platform '${platform}' and architecture '${arch}'`)
+  throw new Error(
+    `Unsupported platform '${platform}' and architecture '${arch}'`
+  )
 }
 
 const baseConfig = {
-    'sudo': 'required',
-    'services': ['docker'],
-    'env': {
-        'global': [
-            `GIT_LFS_VERSION=${getLFSVersion()}`
-        ]
-    },
-    'matrix': {
-        'include': [
-            getConfig('linux', 'amd64'),
-            getConfig('darwin', 'amd64'),
-            getConfig('windows', 'amd64'),
-            getConfig('windows', 'x86'),
-            getConfig('linux', 'arm64'),
-            // shellcheck build step
-            {
-                'os': 'linux',
-                'language': 'shell',
-                'script': [
-                    `bash -c 'shopt -s globstar; shellcheck script/**/*.sh'`
-                ]
-            }
-        ]
-    },
+  sudo: 'required',
+  services: ['docker'],
+  env: {
+    global: [`GIT_LFS_VERSION=${getLFSVersion()}`],
+  },
+  matrix: {
+    include: [
+      getConfig('linux', 'amd64'),
+      getConfig('darwin', 'amd64'),
+      getConfig('windows', 'amd64'),
+      getConfig('windows', 'x86'),
+      getConfig('linux', 'arm64'),
+      // shellcheck build step
+      {
+        os: 'linux',
+        language: 'shell',
+        script: [`bash -c 'shopt -s globstar; shellcheck script/**/*.sh'`],
+      },
+    ],
+  },
 
-    'compiler': ['gcc'],
-    'script': ['script/build.sh && script/package.sh'],
+  compiler: ['gcc'],
+  script: ['script/build.sh && script/package.sh'],
 
-    'branches': {
-        'only': [
-            'master',
-            '/^v[0-9]*.[0-9]*.[0.9]*.*$/'
-        ]
+  branches: {
+    only: ['master', '/^v[0-9]*.[0-9]*.[0.9]*.*$/'],
+  },
+  deploy: {
+    provider: 'releases',
+    api_key: '$GITHUB_TOKEN',
+    file_glob: true,
+    file: [
+      '${TRAVIS_BUILD_DIR}/output/dugite-native-v*.tar.gz',
+      '${TRAVIS_BUILD_DIR}/output/dugite-native-v*.lzma',
+      '${TRAVIS_BUILD_DIR}/output/dugite-native-v*.sha256',
+    ],
+    skip_cleanup: true,
+    draft: true,
+    tag_name: '$TRAVIS_TAG',
+    on: {
+      tags: true,
     },
-    'deploy': {
-        'provider': 'releases',
-        'api_key': '$GITHUB_TOKEN',
-        'file_glob': true,
-        'file': [
-            '${TRAVIS_BUILD_DIR}/output/dugite-native-v*.tar.gz',
-            '${TRAVIS_BUILD_DIR}/output/dugite-native-v*.lzma',
-            '${TRAVIS_BUILD_DIR}/output/dugite-native-v*.sha256'
-        ],
-        'skip_cleanup': true,
-        'draft': true,
-        'tag_name': '$TRAVIS_TAG',
-        'on': {
-            'tags': true
-        }
-    }
+  },
 }
 
 const appveyorFile = path.resolve(__dirname, '..', '.travis.yml')

--- a/script/generate-travis-config.js
+++ b/script/generate-travis-config.js
@@ -143,7 +143,16 @@ const appveyorFile = path.resolve(__dirname, '..', '.travis.yml')
 
 const yaml = YAML.stringify(baseConfig)
 
-// TODO: insert comment lines before file to indicate this is a generated
-//       file and that you should update this script and then run `npm run generate-all-config`
+const commentPreamble = `# NOTE:
+#
+# This config file is generated from a source script and should not be modified
+# manually. If you want to make changes to this config that are remembered
+# between upgrades, ensure that you update \`script/generate-travis-config.js\`,
+# run \`npm run generate-travis-config\` to generate a new config, and commit the
+# change to the repository.
+#`
 
-fs.writeFileSync(appveyorFile, yaml)
+const fileContents = `${commentPreamble}
+${yaml}`
+
+fs.writeFileSync(appveyorFile, fileContents)

--- a/script/generate-travis-config.js
+++ b/script/generate-travis-config.js
@@ -1,0 +1,154 @@
+const fs = require('fs')
+const path = require('path')
+const YAML = require('yaml')
+
+const dependencies = require('../dependencies.json')
+
+function getLFSVersion() {
+    const lfs = dependencies['git-lfs']
+    const fullVersion = lfs.version
+    // trim the leading `v` from the version number
+    return fullVersion.replace('v', '')
+}
+
+function getConfig(platform, arch) {
+
+    const lfs = dependencies['git-lfs']
+    const lfsFile = lfs.files.find(f => f.platform === platform && f.arch === arch)
+    if (lfsFile == null) {
+        throw new Error(`No Git LFS file found for platform ${platform} and arch ${arch}`)
+    }
+
+    if (platform === 'windows') {
+        const git = dependencies['git']
+        const gitPackage = git.packages.find(f => f.platform === platform && f.arch === arch)
+        if (gitPackage == null) {
+            throw new Error(`No Git package found for platform ${platform} and arch ${arch}`)
+        }
+
+        if (arch === 'amd64') {
+            return {
+                'os': 'linux',
+                'language': 'c',
+                'env': [
+                    'TARGET_PLATFORM=win32',
+                    'WIN_ARCH=64',
+                    `GIT_FOR_WINDOWS_URL=${gitPackage.url}`,
+                    `GIT_FOR_WINDOWS_CHECKSUM=${gitPackage.checksum}`,
+                    `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
+                ]
+            }
+        } else if (arch === 'x86') {
+            return {
+                'os': 'linux',
+                'language': 'c',
+                'env': [
+                    'TARGET_PLATFORM=win32',
+                    'WIN_ARCH=32',
+                    `GIT_FOR_WINDOWS_URL=${gitPackage.url}`,
+                    `GIT_FOR_WINDOWS_CHECKSUM=${gitPackage.checksum}`,
+                    `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
+                ]
+            }
+        } else {
+            throw new Error(`Unsupported platform '${platform}' and architecture '${arch}'`)
+        }
+    }
+
+    if (platform === 'darwin' && arch === 'amd64') {
+        return {
+            'os': 'osx',
+            'language': 'c',
+            'env': [
+                'TARGET_PLATFORM=macOS',
+                `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
+            ]
+        }
+    }
+
+    if (platform === 'linux') {
+        if (arch === 'amd64') {
+            return {
+                'os': 'linux',
+                'language': 'c',
+                'env': [
+                    'TARGET_PLATFORM=ubuntu',
+                    `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
+                ]
+            }
+        } else if (arch === 'arm64') {
+            return {
+                'os': 'linux',
+                'language': 'c',
+                'env': [
+                    'TARGET_PLATFORM=arm64',
+                    `GIT_LFS_CHECKSUM=${lfsFile.checksum}`
+                ]
+            }
+        }
+    }
+
+    throw new Error(`Unsupported platform '${platform}' and architecture '${arch}'`)
+}
+
+const baseConfig = {
+    'sudo': 'required',
+    'services': ['docker'],
+    'env': {
+        'global': [
+            `GIT_LFS_VERSION=${getLFSVersion()}`
+        ]
+    },
+    'matrix': {
+        'include': [
+            getConfig('linux', 'amd64'),
+            getConfig('darwin', 'amd64'),
+            getConfig('windows', 'amd64'),
+            getConfig('windows', 'x86'),
+            getConfig('linux', 'arm64'),
+            // shellcheck build step
+            {
+                'os': 'linux',
+                'language': 'shell',
+                'script': [
+                    `bash -c 'shopt -s globstar; shellcheck script/**/*.sh'`
+                ]
+            }
+        ]
+    },
+
+    'compiler': ['gcc'],
+    'script': ['script/build.sh && script/package.sh'],
+
+    'branches': {
+        'only': [
+            'master',
+            '/^v[0-9]*.[0-9]*.[0.9]*.*$/'
+        ]
+    },
+    'deploy': {
+        'provider': 'releases',
+        'api_key': '$GITHUB_TOKEN',
+        'file_glob': true,
+        'file': [
+            '${TRAVIS_BUILD_DIR}/output/dugite-native-v*.tar.gz',
+            '${TRAVIS_BUILD_DIR}/output/dugite-native-v*.lzma',
+            '${TRAVIS_BUILD_DIR}/output/dugite-native-v*.sha256'
+        ],
+        'skip_cleanup': true,
+        'draft': true,
+        'tag_name': '$TRAVIS_TAG',
+        'on': {
+            'tags': true
+        }
+    }
+}
+
+const appveyorFile = path.resolve(__dirname, '..', '.travis.yml')
+
+const yaml = YAML.stringify(baseConfig)
+
+// TODO: insert comment lines before file to indicate this is a generated
+//       file and that you should update this script and then run `npm run generate-all-config`
+
+fs.writeFileSync(appveyorFile, yaml)

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const YAML = require('node-yaml')
+const YAML = require('yaml')
 
 function writeEnvironmentToFile(os, env) {
   const environmentVariables = env.map(a => `${a}`).join('\n')
@@ -109,7 +109,7 @@ echo "\${LZMA_FILE} - \${LZMA_SIZE} - checksum: \${LZMA_CHECKSUM}"
 
 const travisFile = path.resolve(__dirname, '..', '.travis.yml')
 
-const yamlText = fs.readFileSync(travisFile)
+const yamlText = fs.readFileSync(travisFile, 'utf8')
 const yaml = YAML.parse(yamlText)
 
 const globalEnv = yaml['env']['global']


### PR DESCRIPTION
This PR introduces a canonical `dependencies.json` file that defines everything needed for generating a `dugite-native` package.

The goal here is to have a consistent source of truth for things like files and checksums to simplify two things:

 - when upgrading dependencies, have one place to upgrade them (instead of multiple locations with their own quirks)
 - we can derive all the artifacts we need from this source, using a repeatable script rather than manual processes

As part of investigating #140 I found myself wanting to read the YAML config files to use them as a source of truth, but this felt flaky because we have two configs and they often get out of sync because we forget to update one (potentially two if I keep pushing #122 along and use Azure Pipelines).

With this approach, we instead use `dependencies.json` and have a single `generate-all-configs` script that generates all the build configs using the dependencies metadata.

The next step to this is to have a corresponding `npm run update-git-lfs` or `npm run update-git` commands that query for the latest release and update `dependencies.json` to reflect the new bits. Then running `generate-all-configs` will update the configs with new values and everything will be :sparkles:

TODO: 

 - [x] address Appveyor config incompatibilies
 - [x] add generated header to YAML files to indicate they are machine-generated now and to refer to the source files if changes need to be made