### PR TITLE
refreshing the docs

### DIFF
--- a/docs/adding-new-components.md
+++ b/docs/adding-new-components.md
@@ -1,4 +1,4 @@
-# Add a new component
+# Adding new components
 
 If you own or know of a component that you believe should be "in the box" for
 `dugite-native`, please [open a new issue](https://github.com/desktop/dugite-native/issues/new)

--- a/docs/adding-new-components.md
+++ b/docs/adding-new-components.md
@@ -1,0 +1,47 @@
+# Add a new component
+
+If you own or know of a component that you believe should be "in the box" for
+`dugite-native`, please [open a new issue](https://github.com/desktop/dugite-native/issues/new)
+with as much detail as possible about what the package is and why you think it
+is valuable.
+
+## Criteria
+
+The component should satisfy as much of this criteria as possible:
+
+ - **Git-specific** - the component extends Git via configuration, or has a
+   reliable command-line interface
+ - **no graphical user interface** - `dugite-native` is for use inside
+   applications, and is not tailored for end-user interactions
+ - **standalone** - it doesn't depend on any shared libraries or
+   version-specific APIs, because this means more work for distributors
+ - **cross-platform support** - a component that can be used on Windows, macOS
+   and Linux is a much better candidate than a component that only runs on one
+   platform, as it would be usable by a broader audience
+
+## Build Script
+
+For the platforms that `dugite-native` packages, there is a corresponding
+`script/build-{platform}.sh` script. These will need to be updated to obtain
+the sources for this component and add them to the Git distribution before
+packaging.
+
+Use environment variables to represent the contents you need from somewhere
+else.
+
+## Update Script
+
+Aside from those features, the component should have a scriptable way to update
+`dependencies.json` with the specifics it needs:
+
+ - platform-specific resources and where to find them
+ - checksums to verify the resources are correct when packaging
+
+It will also need updates to the scripts that generate config.
+
+A pull request to accept a new component will need this scripting support as a
+pre-requisite. The maintainers are happy to work through with contributors as
+part of the PR review process.
+
+The [Updating Dependencies](https://github.com/desktop/dugite-native/blob/master/docs/updating-dependencies.md)
+document has more information about this process.

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -11,10 +11,9 @@ dependency.
 
 ## Changes to build configuration
 
-To avoid manual changes to build configurations which can be brittle and might
-introduce bugs, there are scripts defined to consume the `dependencies.json`
-file at the root of the repository and generate the required build configuration
-scripts.
+To avoid manual changes to build configurations, which can be brittle and might
+introduce bugs, scripts are used to consume the `dependencies.json` file at the
+root of the repository and generate the required build configuration scripts.
 
 The base config and scripts are found in these files:
 

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -1,20 +1,30 @@
 # Making Changes
 
-To improve the `dugite-native` toolchain, just find the appropriate hook.
+This document outlines how to make changes to the scripts and processes around
+`dugite-native`.
 
-## Update Git
+## Updating Dependencies
 
-If you want to incorporate a new version of Git, first ensure the submodule is
-checked out to the correct tag, e.g:
+If you need to update a dependency, refer to the [Updating Dependencies](https://github.com/desktop/dugite-native/blob/master/docs/updating-dependencies.md)
+document for more information, as there should be an scripted process for each
+dependency.
 
-```
-cd git
-git checkout v2.11.1
-```
+## Changes to build configuration
 
-The package scripts will look for this tag, so non-tagged builds are not
-currently supported. Commit this submodule change and publish a pull request
-to test the packaging changes.
+To avoid manual changes to build configurations which can be brittle and might
+introduce bugs, there are scripts defined to consume the `dependencies.json`
+file at the root of the repository and generate the required build configuration
+scripts.
+
+The base config and scripts are found in these files:
+
+ - [Travis CI](https://github.com/desktop/dugite-native/blob/master/script/generate-travis-config.js)
+ - [Appveyor](https://github.com/desktop/dugite-native/blob/master/script/generate-appveyor-config.js)
+
+Maintainers should make a change to the relevant script and then run
+`npm run generate-all-config` to regenerate all configurations, which will
+combine the latest contents from `dependencies.json` with the base config
+template.
 
 ## Change how Git is built
 
@@ -33,81 +43,3 @@ step with the other Git releases. When a new [Git for Windows](https://github.co
 release is made available, just update the `GIT_FOR_WINDOWS_URL` and
 `GIT_FOR_WINDOWS_CHECKSUM` variables in `.travis.yml` and `appveyor.yml` to use
 their MinGit build.
-
-## Update Git LFS
-
-As Git LFS publishes their releases on GitHub, we have an automated script that
-handles consuming these bits. Assign a `GITHUB_ACCESS_TOKEN` environment
-variable and run this command to perform this update process:
-
-```shellsession
-$ GITHUB_ACCESS_TOKEN=[token] npm run update-git-lfs
-
-> dugite-native@ update-git-lfs /Users/shiftkey/src/dugite-native
-> node script/update-git-lfs.js && npm run prettier-fix
-
-✅ Token found for shiftkey
-✅ Newest git-lfs release 'v2.6.0'
-✅ Found SHA256 signatures for release 'v2.6.0'
-✅ Updated dependencies metadata to Git LFS 'v2.6.0'
-
-> dugite-native@ prettier-fix /Users/shiftkey/src/dugite-native
-> prettier --write **/*.y{,a}ml **/*.{js,ts,json}
-
-.travis.yml 59ms
-appveyor.yml 12ms
-script/generate-appveyor-config.js 70ms
-script/generate-release-notes.js 46ms
-script/generate-travis-config.js 29ms
-script/update-git-lfs.js 21ms
-script/update-test-harness.js 13ms
-dependencies.json 10ms
-package-lock.json 21ms
-package.json 2ms
-```
-
-Review the changes and ensure they look accurate, and then run the
-`generate-all-config` script to refresh the build configs:
-
-```shellsession
-$ npm run generate-all-config
-
-> dugite-native@ generate-all-config /Users/shiftkey/src/dugite-native
-> npm run generate-appveyor-config && npm run generate-travis-config && npm run prettier-fix
-
-
-> dugite-native@ generate-appveyor-config /Users/shiftkey/src/dugite-native
-> node script/generate-appveyor-config.js
-
-
-> dugite-native@ generate-travis-config /Users/shiftkey/src/dugite-native
-> node script/generate-travis-config.js
-
-
-> dugite-native@ prettier-fix /Users/shiftkey/src/dugite-native
-> prettier --write **/*.y{,a}ml **/*.{js,ts,json}
-
-.travis.yml 59ms
-appveyor.yml 13ms
-script/generate-appveyor-config.js 71ms
-script/generate-release-notes.js 42ms
-script/generate-travis-config.js 30ms
-script/update-git-lfs.js 23ms
-script/update-test-harness.js 10ms
-dependencies.json 7ms
-package-lock.json 23ms
-package.json 4ms
-```
-
-You're now ready to commit these changes and create a new pull request.
-
-## Add a new component
-
-If there is some component you think should be incorporated into this package,
-please [open a new issue](https://github.com/desktop/dugite/issues/new) with
-as much detail as possible about what the package is and why you think it is
-valuable.
-
-If the maintainers agree that this is a worthy addition, you are
-then welcome to contribute a pull request to incorporate this. Note that this
-package is intended to be as lean as possible, so make a good case for it!

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -15,10 +15,11 @@ Examples:
 
 ### Release Process
 
-1. `git tag {version}` the version you wish to publish 
-1. `git push origin --tags` to start off the release build
-1. Wait a few minutes for the build to finish
-1. From your machine run this command: `npm run generate-release-notes`
+1. `git tag {version}` the version you wish to publish.
+1. `git push --follow-tags` to ensure all new commits (and the tag) are pushed
+   to the remote. Pushing the tag will start the release process.
+1. Wait a few minutes for the build to finish.
+1. From your machine run this command: `npm run generate-release-notes`.
 
 Pushing the tag triggers a new build for the platforms we need to support. As
 each of those builds completes, the artefacts are published to a draft release

--- a/docs/updating-dependencies.md
+++ b/docs/updating-dependencies.md
@@ -1,0 +1,92 @@
+# Updating Dependencies
+
+To make it easy to manage changes in the dependencies of `dugite-native`, there
+are a collection of scripts and processes that contributors can run.
+
+These scripts require a recent version of [NodeJS](https://nodejs.org/) on their
+machine. These scripts have been tested with Node 8.12, but later versions
+should also be supported.
+
+Before running any of these scripts, ensure you run `npm install` locally to get
+all the dependencies requires for these scripts.
+
+## Update Git
+
+If you want to incorporate a new version of Git, first ensure the submodule is
+checked out to the correct tag, e.g:
+
+```
+cd git
+git checkout v2.11.1
+```
+
+The package scripts will look for this tag, so non-tagged builds are not
+currently supported. Commit this submodule change and publish a pull request
+to test the packaging changes.
+
+## Update Git LFS
+
+As Git LFS publishes their releases on GitHub, we have an automated script that
+handles consuming these bits. Assign a `GITHUB_ACCESS_TOKEN` environment
+variable and run this command to perform this update process:
+
+```shellsession
+$ GITHUB_ACCESS_TOKEN=[token] npm run update-git-lfs
+
+> dugite-native@ update-git-lfs /Users/shiftkey/src/dugite-native
+> node script/update-git-lfs.js && npm run prettier-fix
+
+✅ Token found for shiftkey
+✅ Newest git-lfs release 'v2.6.0'
+✅ Found SHA256 signatures for release 'v2.6.0'
+✅ Updated dependencies metadata to Git LFS 'v2.6.0'
+
+> dugite-native@ prettier-fix /Users/shiftkey/src/dugite-native
+> prettier --write **/*.y{,a}ml **/*.{js,ts,json}
+
+.travis.yml 59ms
+appveyor.yml 12ms
+script/generate-appveyor-config.js 70ms
+script/generate-release-notes.js 46ms
+script/generate-travis-config.js 29ms
+script/update-git-lfs.js 21ms
+script/update-test-harness.js 13ms
+dependencies.json 10ms
+package-lock.json 21ms
+package.json 2ms
+```
+
+Review the changes and ensure they look accurate, and then run the
+`generate-all-config` script to refresh the build configs:
+
+```shellsession
+$ npm run generate-all-config
+
+> dugite-native@ generate-all-config /Users/shiftkey/src/dugite-native
+> npm run generate-appveyor-config && npm run generate-travis-config && npm run prettier-fix
+
+
+> dugite-native@ generate-appveyor-config /Users/shiftkey/src/dugite-native
+> node script/generate-appveyor-config.js
+
+
+> dugite-native@ generate-travis-config /Users/shiftkey/src/dugite-native
+> node script/generate-travis-config.js
+
+
+> dugite-native@ prettier-fix /Users/shiftkey/src/dugite-native
+> prettier --write **/*.y{,a}ml **/*.{js,ts,json}
+
+.travis.yml 59ms
+appveyor.yml 13ms
+script/generate-appveyor-config.js 71ms
+script/generate-release-notes.js 42ms
+script/generate-travis-config.js 30ms
+script/update-git-lfs.js 23ms
+script/update-test-harness.js 10ms
+dependencies.json 7ms
+package-lock.json 23ms
+package.json 4ms
+```
+
+You're now ready to commit these changes and create a new pull request.

--- a/docs/updating-dependencies.md
+++ b/docs/updating-dependencies.md
@@ -21,8 +21,8 @@ git checkout v2.11.1
 ```
 
 The package scripts will look for this tag, so non-tagged builds are not
-currently supported. Commit this submodule change and publish a pull request
-to test the packaging changes.
+currently supported. Commit the `dependencies.json` change as well as  the
+submodule change and open a pull request to test the packaging changes.
 
 ## Update Git LFS
 


### PR DESCRIPTION
This PR updates the documentation about updating dependencies, because now it's significantly more automated.

**Rendered markdown**:

 - [Making Changes](https://github.com/desktop/dugite-native/blob/writing-some-docs/docs/making-changes.md) - updating dependencies is now a scripted process, so this document is now vastly simplified
 - [Updating Dependencies](https://github.com/desktop/dugite-native/blob/writing-some-docs/docs/updating-dependencies.md) - this explains the new scripts for updating Git and Git LFS 
 - [Adding New Components](https://github.com/desktop/dugite-native/blob/writing-some-docs/docs/adding-new-components.md) - to ensure we can support other new components, we need a consistent way to update and package these