### PR TITLE
do some type checking of the current set of scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,12 @@ matrix:
       language: shell
       script:
         - bash -c 'shopt -s globstar; shellcheck script/**/*.sh'
+    - os: linux
+      language: node_js
+      node_js:
+        - node
+      script:
+        - npm run check
 compiler:
   - gcc
 script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,73 @@
         "url-template": "^2.0.8"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.25.tgz",
+      "integrity": "sha512-yfhIBix+AIFTmYGtkC0Bi+XGjSkOINykqKvO/Wqdz/DuXlAKK7HmhLAXdPIGsV4xzKcL3ev/zYc4yLNo+OvGaw==",
+      "dev": true
+    },
+    "@types/caseless": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
+      "dev": true
+    },
+    "@types/form-data": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "10.12.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+      "integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
+      "dev": true
+    },
+    "@types/request": {
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
+      "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/form-data": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
+    "@types/request-promise": {
+      "version": "4.1.42",
+      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.42.tgz",
+      "integrity": "sha512-b8li55sEZ00BXZstZ3d8WOi48dnapTqB1VufEG9Qox0nVI2JVnTVT1Mw4JbBa1j+1sGVX/qJ0R4WDv4v2GjT0w==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/request": "*"
+      }
+    },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-Set5ZdrAaKI/qHdFlVMgm/GsAv/wkXhSTuZFkJ+JI7HK+wIkIlOaUXSXieIvJ0+OvGIqtREFoE+NHJtEq0gtEw==",
+      "dev": true
+    },
+    "@types/yaml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.0.1.tgz",
+      "integrity": "sha512-Bq8/v5jtk4TsPY4qSmlEM2hucw5vgA7jWaDV6NFNv6ZjSoqxicRB5RH8Cc1eMEr0VcbgnysGIujg6hR3nZ14sw==",
+      "dev": true
+    },
     "agent-base": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -554,6 +554,12 @@
       "dev": true,
       "optional": true
     },
+    "typescript": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "dev": true
+    },
     "universal-user-agent": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dugite-native",
   "description": "ad-hoc scripts for helping to contribute",
   "scripts": {
+    "check": "tsc",
     "update-test-harness": "node script/update-test-harness.js",
     "update-git": "node script/update-git.js && npm run prettier-fix",
     "update-git-lfs": "node script/update-git-lfs.js && npm run prettier-fix",
@@ -28,6 +29,7 @@
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "semver": "^5.6.0",
+    "typescript": "^3.2.2",
     "yaml": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
   "homepage": "https://github.com/desktop/dugite-native#readme",
   "devDependencies": {
     "@octokit/rest": "^15.12.0",
+    "@types/node": "^10.12.15",
+    "@types/request-promise": "^4.1.42",
+    "@types/semver": "^5.5.0",
+    "@types/yaml": "^1.0.1",
     "prettier": "^1.15.2",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",

--- a/script/generate-appveyor-config.js
+++ b/script/generate-appveyor-config.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const YAML = require('yaml')
 
-/** @type {{'git-lfs': any, git: any }} */
+/** @type {{'git-lfs': {version: string, files: Array<{platform: string, arch: string, name: string, checksum: string}>}, git: {packages: Array<{platform: string, arch: string, url: string, checksum: string}>} }} */
 const dependencies = require('../dependencies.json')
 
 function getLFSVersion() {
@@ -22,7 +22,6 @@ function getConfig(
     throw new Error(`Unsupported platform '${platform}'`)
   }
 
-  /** @type {{packages: Array<{platform: string, arch: string, url: string, checksum: string}>}} */
   const git = dependencies['git']
   const gitPackage = git.packages.find(
     f => f.platform === platform && f.arch === arch
@@ -33,7 +32,6 @@ function getConfig(
     )
   }
 
-  /** @type {{files: Array<{platform: string, arch: string, name: string, checksum: string}>}} */
   const lfs = dependencies['git-lfs']
   const lfsFile = lfs.files.find(
     f => f.platform === platform && f.arch === arch

--- a/script/generate-appveyor-config.js
+++ b/script/generate-appveyor-config.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const YAML = require('yaml')
 
+/** @type {{'git-lfs': any, git: any }} */
 const dependencies = require('../dependencies.json')
 
 function getLFSVersion() {
@@ -11,11 +12,17 @@ function getLFSVersion() {
   return fullVersion.replace('v', '')
 }
 
-function getConfig(platform, arch) {
+function getConfig(
+  /** @type {string} */
+  platform,
+  /** @type {string} */
+  arch
+) {
   if (platform !== 'windows') {
     throw new Error(`Unsupported platform '${platform}'`)
   }
 
+  /** @type {{packages: Array<{platform: string, arch: string, url: string, checksum: string}>}} */
   const git = dependencies['git']
   const gitPackage = git.packages.find(
     f => f.platform === platform && f.arch === arch
@@ -26,6 +33,7 @@ function getConfig(platform, arch) {
     )
   }
 
+  /** @type {{files: Array<{platform: string, arch: string, name: string, checksum: string}>}} */
   const lfs = dependencies['git-lfs']
   const lfsFile = lfs.files.find(
     f => f.platform === platform && f.arch === arch

--- a/script/generate-release-notes.js
+++ b/script/generate-release-notes.js
@@ -11,7 +11,12 @@ process.on('unhandledRejection', reason => {
   console.log(reason)
 })
 
-async function getBuildUrl(octokit, owner, repo, ref) {
+async function getBuildUrl(
+  /** @type {Octokit} */ octokit,
+  /** @type {string} */ owner,
+  /** @type {string} */ repo,
+  /** @type {string} */ ref
+) {
   const response = await octokit.repos.getStatuses({
     owner,
     repo,
@@ -53,10 +58,11 @@ async function run() {
     token,
   })
 
-  const user = await octokit.users.get()
+  const user = await octokit.users.get({})
   const me = user.data.login
 
   console.log(`✅ Token found for ${me}`)
+  // @ts-ignore
   const foundScopes = user.headers['x-oauth-scopes']
   if (foundScopes.indexOf('public_repo') === -1) {
     console.log(
@@ -90,7 +96,7 @@ async function run() {
   const assets = await octokit.repos.getAssets({
     owner,
     repo,
-    release_id: id,
+    release_id: id.toString(),
   })
 
   if (assets.data.length !== SUCCESSFUL_RELEASE_FILE_COUNT) {
@@ -135,6 +141,7 @@ async function run() {
 
   const latestReleaseTag = latestRelease.data.tag_name
 
+  /** @type {{ data: { commits: Array<{commit: { message: string }}>} }} */
   const response = await octokit.repos.compareCommits({
     owner,
     repo,
@@ -154,8 +161,11 @@ async function run() {
 
   for (const mergeCommitMessage of mergeCommitMessages) {
     const match = mergeCommitRegex.exec(mergeCommitMessage)
-    if (match.length === 2) {
-      pullRequestIds.push(match[1])
+    if (match != null && match.length === 2) {
+      const num = parseInt(match[1])
+      if (num != NaN) {
+        pullRequestIds.push(num)
+      }
     }
   }
 
@@ -187,7 +197,7 @@ ${fileListText}`
   const result = await octokit.repos.editRelease({
     owner: 'desktop',
     repo: 'dugite-native',
-    release_id: id,
+    release_id: id.toString(),
     tag_name,
     name: `Git ${numberWithoutPrefix}`,
     body: draftReleaseNotes,

--- a/script/generate-release-notes.js
+++ b/script/generate-release-notes.js
@@ -1,4 +1,5 @@
-const octokit = require('@octokit/rest')()
+const Octokit = require('@octokit/rest')
+const octokit = new Octokit()
 const rp = require('request-promise')
 
 // five targeted OS/arch combinations

--- a/script/generate-travis-config.js
+++ b/script/generate-travis-config.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const YAML = require('yaml')
 
+/** @type {{'git-lfs': any, git: any }} */
 const dependencies = require('../dependencies.json')
 
 function getLFSVersion() {
@@ -11,7 +12,13 @@ function getLFSVersion() {
   return fullVersion.replace('v', '')
 }
 
-function getConfig(platform, arch) {
+function getConfig(
+  /** @type {string} */
+  platform,
+  /** @type {string} */
+  arch
+) {
+  /** @type {{files: Array<{platform: string, arch: string, name: string, checksum: string}>}} */
   const lfs = dependencies['git-lfs']
   const lfsFile = lfs.files.find(
     f => f.platform === platform && f.arch === arch
@@ -23,6 +30,7 @@ function getConfig(platform, arch) {
   }
 
   if (platform === 'windows') {
+    /** @type {{packages: Array<{platform: string, arch: string, url: string, checksum: string}>}} */
     const git = dependencies['git']
     const gitPackage = git.packages.find(
       f => f.platform === platform && f.arch === arch

--- a/script/generate-travis-config.js
+++ b/script/generate-travis-config.js
@@ -112,6 +112,13 @@ const baseConfig = {
         language: 'shell',
         script: [`bash -c 'shopt -s globstar; shellcheck script/**/*.sh'`],
       },
+      // verify tooling scripts
+      {
+        os: 'linux',
+        language: 'node_js',
+        node_js: ['node'],
+        script: [`npm run check`],
+      },
     ],
   },
 

--- a/script/generate-travis-config.js
+++ b/script/generate-travis-config.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const YAML = require('yaml')
 
-/** @type {{'git-lfs': any, git: any }} */
+/** @type {{'git-lfs': {version: string, files: Array<{platform: string, arch: string, name: string, checksum: string}>}, git: {packages: Array<{platform: string, arch: string, url: string, checksum: string}>} }} */
 const dependencies = require('../dependencies.json')
 
 function getLFSVersion() {
@@ -18,7 +18,6 @@ function getConfig(
   /** @type {string} */
   arch
 ) {
-  /** @type {{files: Array<{platform: string, arch: string, name: string, checksum: string}>}} */
   const lfs = dependencies['git-lfs']
   const lfsFile = lfs.files.find(
     f => f.platform === platform && f.arch === arch

--- a/script/update-git-lfs.js
+++ b/script/update-git-lfs.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const fs = require('fs')
-const octokit = require('@octokit/rest')()
+const Octokit = require('@octokit/rest')
+const octokit = new Octokit()
 const rp = require('request-promise')
 
 process.on('unhandledRejection', reason => {

--- a/script/update-git-lfs.js
+++ b/script/update-git-lfs.js
@@ -8,9 +8,14 @@ process.on('unhandledRejection', reason => {
   console.log(reason)
 })
 
-function updateDependencies(version, files) {
+function updateDependencies(
+  /** @type {string} */
+  version,
+  /** @type {Array<{platform: string, arch: string, name: string, checksum: string}>} */
+  files
+) {
   const dependenciesPath = path.resolve(__dirname, '..', 'dependencies.json')
-  const dependenciesText = fs.readFileSync(dependenciesPath)
+  const dependenciesText = fs.readFileSync(dependenciesPath, 'utf8')
   const dependencies = JSON.parse(dependenciesText)
 
   const gitLfs = {
@@ -25,7 +30,7 @@ function updateDependencies(version, files) {
   fs.writeFileSync(dependenciesPath, newDepedenciesText, 'utf8')
 }
 
-function getPlatform(fileName) {
+function getPlatform(/** @type {string} */ fileName) {
   if (fileName.match(/-windows-/)) {
     return 'windows'
   }
@@ -39,7 +44,7 @@ function getPlatform(fileName) {
   throw new Error(`Unable to find platform for file: ${fileName}`)
 }
 
-function getArch(fileName) {
+function getArch(/** @type {string} */ fileName) {
   if (fileName.match(/-amd64-/)) {
     return 'amd64'
   }
@@ -65,7 +70,7 @@ async function run() {
     token,
   })
 
-  const user = await octokit.users.get()
+  const user = await octokit.users.get({})
   const me = user.data.login
 
   console.log(`✅ Token found for ${me}`)
@@ -80,16 +85,17 @@ async function run() {
 
   console.log(`✅ Newest git-lfs release '${version}'`)
 
+  /** @type {{ data: Array<{name: string, url: string}>}} */
   const assets = await octokit.repos.getAssets({
     owner,
     repo,
-    release_id: id,
+    release_id: id.toString(),
   })
 
   const signaturesFile = assets.data.find(a => a.name === 'sha256sums.asc')
 
   if (signaturesFile == null) {
-    const foundFiles = assets.map(a => a.name)
+    const foundFiles = assets.data.map(a => a.name)
     console.log(
       `🔴 Could not find signatures. Got files: ${JSON.stringify(foundFiles)}`
     )
@@ -124,11 +130,12 @@ async function run() {
   for (const file of files) {
     const re = new RegExp(`([0-9a-z]{64})\\s*${file}`)
     const match = re.exec(fileContents)
+    const platform = getPlatform(file)
     if (match == null) {
       console.log(`🔴 Could not find entry for file ${platform}`)
     } else {
       newFiles.push({
-        platform: getPlatform(file),
+        platform,
         arch: getArch(file),
         name: file,
         checksum: match[1],

--- a/script/update-git.js
+++ b/script/update-git.js
@@ -13,7 +13,12 @@ process.on('unhandledRejection', reason => {
 const root = path.dirname(__dirname)
 const gitDir = path.join(root, 'git')
 
-function spawn(cmd, args, cwd) {
+/** @returns {Promise<string>} */
+function spawn(
+  /** @type {string} */ cmd,
+  /** @type {Array<string>} */ args,
+  /** @type {string} */ cwd
+) {
   return new Promise((resolve, reject) => {
     const child = ChildProcess.spawn(cmd, args, { cwd })
     let receivedData = ''
@@ -44,7 +49,7 @@ async function refreshGitSubmodule() {
   await spawn('git', ['fetch', '--tags'], gitDir)
 }
 
-async function checkout(tag) {
+async function checkout(/** @type {string} */ tag) {
   await spawn('git', ['checkout', tag], gitDir)
 }
 
@@ -59,10 +64,14 @@ async function getLatestStableRelease() {
   const sortedTags = semver.sort(releaseTags)
   const latestTag = sortedTags[sortedTags.length - 1]
 
-  return latestTag
+  return latestTag.toString()
 }
 
-function getPackageDetails(assets, body, arch) {
+function getPackageDetails(
+  /** @type {Array<{name: string, url: string, browser_download_url: string}>} */ assets,
+  /** @type {string} */ body,
+  /** @type {string} */ arch
+) {
   const archValue = arch === 'amd64' ? '64-bit' : '32-bit'
 
   const minGitFile = assets.find(
@@ -97,9 +106,12 @@ function getPackageDetails(assets, body, arch) {
   }
 }
 
-function updateDependencies(version, packages) {
+function updateDependencies(
+  /** @type {string} */ version,
+  /** @type {Array<{platform: string, arch: string, filename: string, url: string, checksum: string}>} */ packages
+) {
   const dependenciesPath = path.resolve(__dirname, '..', 'dependencies.json')
-  const dependenciesText = fs.readFileSync(dependenciesPath)
+  const dependenciesText = fs.readFileSync(dependenciesPath, 'utf8')
   const dependencies = JSON.parse(dependenciesText)
 
   const git = {
@@ -133,7 +145,7 @@ async function run() {
     token,
   })
 
-  const user = await octokit.users.get()
+  const user = await octokit.users.get({})
   const me = user.data.login
 
   console.log(`✅ Token found for ${me}`)

--- a/script/update-git.js
+++ b/script/update-git.js
@@ -1,7 +1,8 @@
 const path = require('path')
 const fs = require('fs')
 const ChildProcess = require('child_process')
-const octokit = require('@octokit/rest')()
+const Octokit = require('@octokit/rest')
+const octokit = new Octokit()
 
 const semver = require('semver')
 

--- a/script/update-test-harness.js
+++ b/script/update-test-harness.js
@@ -2,7 +2,10 @@ const fs = require('fs')
 const path = require('path')
 const YAML = require('yaml')
 
-function writeEnvironmentToFile(os, env) {
+function writeEnvironmentToFile(
+  /** @type {string} */ os,
+  /** @type {Array<string>} */ env
+) {
   const environmentVariables = env.map(a => `${a}`).join('\n')
 
   const script = `build-${os}.sh`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "commonjs",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["script/*.js"]
+}


### PR DESCRIPTION
This PR adds support for type-checking the current JS files without rewriting them to `.ts` files. [This wiki page](https://github.com/Microsoft/TypeScript/wiki/Type-Checking-JavaScript-Files) is a good walkthrough of the hooks available.

This adds an additional step to the build matrix to `npm run check`, which uses a simple `tsconfig.json` to process all the `script/*.js` files. I'll annotate the rest of the PR with the other changes as that's easier to explain there.