### PR TITLE
Update Git to v2.20.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,16 +40,16 @@ matrix:
       env:
         - TARGET_PLATFORM=win32
         - WIN_ARCH=64
-        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.19.2.windows.1/MinGit-2.19.2-64-bit.zip
-        - GIT_FOR_WINDOWS_CHECKSUM=9d260fd4b9cf279491a1cc6762c2f08f7e8ca6c1d6492300cacbc800fe384a0f
+        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.20.1.windows.1/MinGit-2.20.1-64-bit.zip
+        - GIT_FOR_WINDOWS_CHECKSUM=02328f37eeefe8d8f5396553ac8f91c98d09e533d49d93c617a4643915a76552
         - GIT_LFS_CHECKSUM=35d0a62c5e36131b7ba65352146c585eaf1f33d7a229b9471082f49fca53b952
     - os: linux
       language: c
       env:
         - TARGET_PLATFORM=win32
         - WIN_ARCH=32
-        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.19.2.windows.1/MinGit-2.19.2-32-bit.zip
-        - GIT_FOR_WINDOWS_CHECKSUM=a85f4343628e7591a60ced4d54df176dba1c599b9097d1dc86597fd00bc3a5b3
+        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.20.1.windows.1/MinGit-2.20.1-32-bit.zip
+        - GIT_FOR_WINDOWS_CHECKSUM=a51b66795c45e3cd1a6041fa6bcc606175870bb2c777f4cfc3dc12c7973ae634
         - GIT_LFS_CHECKSUM=90bbeb7dc4ada394624d3a2675fd51dd4873753a56fb197b17bc01c9fcc91398
     - os: linux
       language: c

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,13 +13,13 @@ environment:
   matrix:
     - TARGET_PLATFORM: win32
       WIN_ARCH: 64
-      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.19.2.windows.1/MinGit-2.19.2-64-bit.zip
-      GIT_FOR_WINDOWS_CHECKSUM: 9d260fd4b9cf279491a1cc6762c2f08f7e8ca6c1d6492300cacbc800fe384a0f
+      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.20.1.windows.1/MinGit-2.20.1-64-bit.zip
+      GIT_FOR_WINDOWS_CHECKSUM: 02328f37eeefe8d8f5396553ac8f91c98d09e533d49d93c617a4643915a76552
       GIT_LFS_CHECKSUM: 35d0a62c5e36131b7ba65352146c585eaf1f33d7a229b9471082f49fca53b952
     - TARGET_PLATFORM: win32
       WIN_ARCH: 32
-      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.19.2.windows.1/MinGit-2.19.2-32-bit.zip
-      GIT_FOR_WINDOWS_CHECKSUM: a85f4343628e7591a60ced4d54df176dba1c599b9097d1dc86597fd00bc3a5b3
+      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.20.1.windows.1/MinGit-2.20.1-32-bit.zip
+      GIT_FOR_WINDOWS_CHECKSUM: a51b66795c45e3cd1a6041fa6bcc606175870bb2c777f4cfc3dc12c7973ae634
       GIT_LFS_CHECKSUM: 90bbeb7dc4ada394624d3a2675fd51dd4873753a56fb197b17bc01c9fcc91398
 build_script:
   - git submodule update --init --recursive

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,20 +1,20 @@
 {
   "git": {
-    "version": "v2.19.2",
+    "version": "v2.20.1",
     "packages": [
       {
         "platform": "windows",
         "arch": "amd64",
-        "filename": "MinGit-2.19.2-64-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.19.2.windows.1/MinGit-2.19.2-64-bit.zip",
-        "checksum": "9d260fd4b9cf279491a1cc6762c2f08f7e8ca6c1d6492300cacbc800fe384a0f"
+        "filename": "MinGit-2.20.1-64-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.20.1.windows.1/MinGit-2.20.1-64-bit.zip",
+        "checksum": "02328f37eeefe8d8f5396553ac8f91c98d09e533d49d93c617a4643915a76552"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "filename": "MinGit-2.19.2-32-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.19.2.windows.1/MinGit-2.19.2-32-bit.zip",
-        "checksum": "a85f4343628e7591a60ced4d54df176dba1c599b9097d1dc86597fd00bc3a5b3"
+        "filename": "MinGit-2.20.1-32-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.20.1.windows.1/MinGit-2.20.1-32-bit.zip",
+        "checksum": "a51b66795c45e3cd1a6041fa6bcc606175870bb2c777f4cfc3dc12c7973ae634"
       }
     ]
   },

--- a/script/build-arm64-git.sh
+++ b/script/build-arm64-git.sh
@@ -25,6 +25,7 @@ make configure
 CC='gcc' \
   CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
   LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro' \
+  CURL_CONFIG="$CURL_INSTALL_DIR/bin/curl-config" \
   ./configure \
   --with-curl="$CURL_INSTALL_DIR" \
   --prefix=/

--- a/script/build-arm64.sh
+++ b/script/build-arm64.sh
@@ -40,7 +40,7 @@ docker run -it \
 -e "DESTINATION=$DESTINATION" \
 -e "CURL_INSTALL_DIR=$CURL_INSTALL_DIR" \
 -w="$BASEDIR" \
---rm shiftkey/dugite-native:arm64-jessie-git-with-curl sh "$BASEDIR/script/build-arm64-git.sh"
+--rm shiftkey/dugite-native:arm64-jessie-git-with-curl bash "$BASEDIR/script/build-arm64-git.sh"
 
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"


### PR DESCRIPTION
I was originally planning to go to `v2.20.0` but it looks like `v2.20.1` dropped yesterday to address a couple of reported breakages:

 - [Git v2.20.0 release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.20.0.txt)
 - [Git v2.20.1 release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.20.1.txt)
 - [Git for Windows v2.20.0 release notes](https://github.com/git-for-windows/git/releases/tag/v2.20.0.windows.1)
 - [Git for Windows v2.20.1 release notes](https://github.com/git-for-windows/git/releases/tag/v2.20.1.windows.1)

TODO:

 - [x] ensure ARM64 build is run in `bash` as some syntax doesn't seem to be detected in `sh`

```
/home/travis/build/desktop/dugite-native/script/build-arm64-git.sh: 5: /home/travis/build/desktop/dugite-native/script/build-arm64-git.sh: [[: not found
/home/travis/build/desktop/dugite-native/script/build-arm64-git.sh: 10: /home/travis/build/desktop/dugite-native/script/build-arm64-git.sh: [[: not found
/home/travis/build/desktop/dugite-native/script/build-arm64-git.sh: 15: /home/travis/build/desktop/dugite-native/script/build-arm64-git.sh: [[: not found
```

 - [x] address ARM64 build issue with `curl-config` not being found (bump container?)

```
make: curl-config: Command not found
    LINK git-http-fetch
http.o: In function `process_curl_messages':
/home/travis/build/desktop/dugite-native/git/http.c:260: undefined reference to `curl_multi_info_read'
http.o: In function `xmulti_remove_handle':
/home/travis/build/desktop/dugite-native/git/http.c:251: undefined reference to `curl_multi_remove_handle'
http.o: In function `finish_active_slot':
/home/travis/build/desktop/dugite-native/git/http.c:223: undefined reference to `curl_easy_getinfo'
/home/travis/build/desktop/dugite-native/git/http.c:233: undefined reference to `curl_easy_getinfo'
/home/travis/build/desktop/dugite-native/git/http.c:239: undefined reference to `curl_easy_getinfo'
http.o: In function `process_curl_messages':
/home/travis/build/desktop/dugite-native/git/http.c:280: undefined reference to `curl_multi_info_read'
http.o: In function `http_opt_request_remainder':
/home/travis/build/desktop/dugite-native/git/http.c:1794: undefined reference to `curl_easy_setopt'
...
```