### PR TITLE
fail the travis build if any step triggers an error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   global:
     - GIT_LFS_VERSION=2.6.1
 matrix:
+  fast_finish: true
   include:
     - os: linux
       language: c

--- a/script/generate-travis-config.js
+++ b/script/generate-travis-config.js
@@ -107,6 +107,7 @@ const baseConfig = {
     global: [`GIT_LFS_VERSION=${getLFSVersion()}`],
   },
   matrix: {
+    fast_finish: true,
     include: [
       getConfig('linux', 'amd64'),
       getConfig('darwin', 'amd64'),


### PR DESCRIPTION
I spotted that #152 introduced an error, but it didn't report the error until all the agents had completed.

I want faster feedback than that, and I think this is the right config flag based on [this post](https://blog.travis-ci.com/2013-11-27-fast-finishing-builds).