### PR TITLE
run shellcheck and js check steps before packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,16 @@ matrix:
   fast_finish: true
   include:
     - os: linux
+      language: shell
+      script:
+        - bash -c 'shopt -s globstar; shellcheck script/**/*.sh'
+    - os: linux
+      language: node_js
+      node_js:
+        - node
+      script:
+        - npm run check && npm run prettier
+    - os: linux
       language: c
       env:
         - TARGET_PLATFORM=ubuntu
@@ -46,16 +56,6 @@ matrix:
       env:
         - TARGET_PLATFORM=arm64
         - GIT_LFS_CHECKSUM=5624ca015537333b459fa3817da7257a73ed612d958eccc596e6118b4bf6a5c6
-    - os: linux
-      language: shell
-      script:
-        - bash -c 'shopt -s globstar; shellcheck script/**/*.sh'
-    - os: linux
-      language: node_js
-      node_js:
-        - node
-      script:
-        - npm run check && npm run prettier
 compiler:
   - gcc
 script:

--- a/script/generate-travis-config.js
+++ b/script/generate-travis-config.js
@@ -109,11 +109,6 @@ const baseConfig = {
   matrix: {
     fast_finish: true,
     include: [
-      getConfig('linux', 'amd64'),
-      getConfig('darwin', 'amd64'),
-      getConfig('windows', 'amd64'),
-      getConfig('windows', 'x86'),
-      getConfig('linux', 'arm64'),
       // shellcheck build step
       {
         os: 'linux',
@@ -127,6 +122,11 @@ const baseConfig = {
         node_js: ['node'],
         script: [`npm run check && npm run prettier`],
       },
+      getConfig('linux', 'amd64'),
+      getConfig('darwin', 'amd64'),
+      getConfig('windows', 'amd64'),
+      getConfig('windows', 'x86'),
+      getConfig('linux', 'arm64'),
     ],
   },
 


### PR DESCRIPTION
I believe the matrix of build configs is prioritized from top-to-bottom (based on agent availability), so this PR prioritizes `shellcheck` and `npm run check` (both running on Linux agents) before any of the packaging build configs.

This will help with #156 to verify build scripts before they are run.