### PR TITLE
regenerate config to consume new git-lfs update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
   - docker
 env:
   global:
-    - GIT_LFS_VERSION=2.6.1
+    - GIT_LFS_VERSION=2.7.2
 matrix:
   fast_finish: true
   include:
@@ -29,12 +29,12 @@ matrix:
       language: c
       env:
         - TARGET_PLATFORM=ubuntu
-        - GIT_LFS_CHECKSUM=c098092be413915793214a570cd51ef46089b6f6616b2f78e35ba374de613b5b
+        - GIT_LFS_CHECKSUM=89f5aa2c29800bbb71f5d4550edd69c5f83e3ee9e30f770446436dd7f4ef1d4c
     - os: osx
       language: c
       env:
         - TARGET_PLATFORM=macOS
-        - GIT_LFS_CHECKSUM=84ac4953c55bbaf87efd1c3d5b7778b1cf0b257025d2a86d709a2bf301c32c8b
+        - GIT_LFS_CHECKSUM=f67da07561c25889af56b1fd873c074eb240a0fad853989fec9923c1c1acb826
     - os: linux
       language: c
       env:
@@ -42,7 +42,7 @@ matrix:
         - WIN_ARCH=64
         - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip
         - GIT_FOR_WINDOWS_CHECKSUM=bd91db55bd95eaa80687df28877e2df8c8858a0266e9c67331cfddba2735f25c
-        - GIT_LFS_CHECKSUM=35d0a62c5e36131b7ba65352146c585eaf1f33d7a229b9471082f49fca53b952
+        - GIT_LFS_CHECKSUM=5cbe0765d469bbb32548a86e92d5e8694f1e97df7d590552477c3fafdc6c82e1
     - os: linux
       language: c
       env:
@@ -50,12 +50,12 @@ matrix:
         - WIN_ARCH=32
         - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-32-bit.zip
         - GIT_FOR_WINDOWS_CHECKSUM=652c05175553e25401e38c7e65467d92748fc5d577374c9587c09f5875d8937e
-        - GIT_LFS_CHECKSUM=90bbeb7dc4ada394624d3a2675fd51dd4873753a56fb197b17bc01c9fcc91398
+        - GIT_LFS_CHECKSUM=f4f49e9261584711c337f566a62bd9645cc0e10cef4dc54de1e1e0d31a7b2f71
     - os: linux
       language: c
       env:
         - TARGET_PLATFORM=arm64
-        - GIT_LFS_CHECKSUM=5624ca015537333b459fa3817da7257a73ed612d958eccc596e6118b4bf6a5c6
+        - GIT_LFS_CHECKSUM=ea628d95158d5c76d9c7fe9432f28e49cc1a1b7ae3928b7089b1f4f97748d7a0
 compiler:
   - gcc
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,18 +9,18 @@
 image: Visual Studio 2015
 skip_branch_with_pr: true
 environment:
-  GIT_LFS_VERSION: 2.6.1
+  GIT_LFS_VERSION: 2.7.2
   matrix:
     - TARGET_PLATFORM: win32
       WIN_ARCH: 64
       GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip
       GIT_FOR_WINDOWS_CHECKSUM: bd91db55bd95eaa80687df28877e2df8c8858a0266e9c67331cfddba2735f25c
-      GIT_LFS_CHECKSUM: 35d0a62c5e36131b7ba65352146c585eaf1f33d7a229b9471082f49fca53b952
+      GIT_LFS_CHECKSUM: 5cbe0765d469bbb32548a86e92d5e8694f1e97df7d590552477c3fafdc6c82e1
     - TARGET_PLATFORM: win32
       WIN_ARCH: 32
       GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-32-bit.zip
       GIT_FOR_WINDOWS_CHECKSUM: 652c05175553e25401e38c7e65467d92748fc5d577374c9587c09f5875d8937e
-      GIT_LFS_CHECKSUM: 90bbeb7dc4ada394624d3a2675fd51dd4873753a56fb197b17bc01c9fcc91398
+      GIT_LFS_CHECKSUM: f4f49e9261584711c337f566a62bd9645cc0e10cef4dc54de1e1e0d31a7b2f71
 build_script:
   - git submodule update --init --recursive
   - bash script\build.sh


### PR DESCRIPTION
I overlooked doing this in #259 to ensure we're building with the new `git-lfs` release