### PR TITLE
Adding credential helpers for windows and mac

### DIFF
--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -31,6 +31,12 @@ DESTDIR="$DESTINATION" make strip install prefix=/ \
     MACOSX_DEPLOYMENT_TARGET=10.9
 )
 
+(
+cd "$SOURCE/contrib/credential/osxkeychain" || exit 1
+make clean
+make
+cp "$SOURCE/contrib/credential/osxkeychain/git-credential-osxkeychain" "$DESTINATION/libexec/git-core/"
+)
 
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -90,5 +90,4 @@ rm "$DESTINATION/$MINGW_DIR/etc/gitattributes"
 echo "-- Removing global gitattributes which handles certain file extensions"
 
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-store.exe"
-rm "$DESTINATION/$MINGW_DIR/bin/git-credential-wincred.exe"
 echo "-- Removing legacy credential helpers"


### PR DESCRIPTION
Hey hey! :wave:

So I really want to switch to dugite-native in GitHub for Unity, but it's missing wincred and osxkeychain, which are kinda important for managing credentials (there's no keychain credential helper on mac, and the manager on Windows has some unfortunate side effects that make it a problem to use when shelling out to git from Unity). This adds wincred and osxkeychain to the packaging. I'd rather not maintain a fork for this stuff, what are your feels on having these two utilities in the packages?