### PR TITLE
Strip system gitattributes file and update system git config file location

### DIFF
--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -65,6 +65,20 @@ fi
 
 SYSTEM_CONFIG="$DESTINATION/etc/gitconfig"
 
+# Make sure that the system config file is where we expect it to be...
+if [[ ! -f "$SYSTEM_CONFIG" ]]; then
+  echo "Global git config file not found in expected location: $SYSTEM_CONFIG"
+  echo "aborting..."
+  exit 1
+fi
+
+# ...and nowhere else.
+if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitconfig" ]]; then
+  echo "Global git config file found in unexpected location: $DESTINATION/$MINGW_DIR/etc/gitconfig"
+  echo "aborting..."
+  exit 1
+fi
+
 echo "-- Setting some system configuration values"
 git config --file "$SYSTEM_CONFIG" core.symlinks "false"
 git config --file "$SYSTEM_CONFIG" core.autocrlf "true"
@@ -87,6 +101,18 @@ git config --file "$SYSTEM_CONFIG" http.schannelUseSSLCAInfo "false"
 
 # removing global gitattributes file
 echo "-- Removing global gitattributes which handles certain file extensions"
+
+if [[ ! -f "$DESTINATION/etc/gitattributes" ]]; then
+  echo "Global git attributes file not found in expected location: $DESTINATION/etc/gitattributes"
+  echo "aborting..."
+  exit 1
+fi
+
+if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitattributes" ]]; then
+  echo "Global git attributes file found in unexpected location: $DESTINATION/$MINGW_DIR/etc/gitattributes"
+  echo "aborting..."
+  exit 1
+fi
 rm "$DESTINATION/etc/gitattributes"
 
 echo "-- Removing legacy credential helpers"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -109,7 +109,7 @@ if [[ -f "$DESTINATION/etc/gitattributes" ]]; then
     echo "aborting..."
     exit 1
   fi
-else if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitattributes" ]]
+elif [[ -f "$DESTINATION/$MINGW_DIR/etc/gitattributes" ]]; then
   SYSTEM_GITATTRIBUTES="$DESTINATION/$MINGW_DIR/etc/gitattributes"
 fi
 

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -113,7 +113,7 @@ elif [[ -f "$DESTINATION/$MINGW_DIR/etc/gitattributes" ]]; then
   SYSTEM_GITATTRIBUTES="$DESTINATION/$MINGW_DIR/etc/gitattributes"
 fi
 
-rm "$DESTINATION/etc/gitattributes"
+rm "$SYSTEM_GITATTRIBUTES"
 
 echo "-- Removing legacy credential helpers"
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-store.exe"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -102,7 +102,7 @@ git config --file "$SYSTEM_CONFIG" http.schannelUseSSLCAInfo "false"
 echo "-- Removing system level gitattributes which handles certain file extensions"
 
 if [[ -f "$DESTINATION/etc/gitattributes" ]]; then
-  SYSTEM_GITATTRIBUTES="$DESTINATION/etc/gitattributes"
+  rm "$DESTINATION/etc/gitattributes"
 
   if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitattributes" ]]; then
     echo "System level git attributes file found in both locations"
@@ -110,10 +110,8 @@ if [[ -f "$DESTINATION/etc/gitattributes" ]]; then
     exit 1
   fi
 elif [[ -f "$DESTINATION/$MINGW_DIR/etc/gitattributes" ]]; then
-  SYSTEM_GITATTRIBUTES="$DESTINATION/$MINGW_DIR/etc/gitattributes"
+  rm "$DESTINATION/$MINGW_DIR/etc/gitattributes"
 fi
-
-rm "$SYSTEM_GITATTRIBUTES"
 
 echo "-- Removing legacy credential helpers"
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-store.exe"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -62,19 +62,18 @@ else
   echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi
 
+if [[ -f "$DESTINATION/etc/gitconfig" ]]; then
+  SYSTEM_CONFIG="$DESTINATION/etc/gitconfig"
 
-SYSTEM_CONFIG="$DESTINATION/etc/gitconfig"
-
-# Make sure that the system config file is where we expect it to be...
-if [[ ! -f "$SYSTEM_CONFIG" ]]; then
-  echo "Global git config file not found in expected location: $SYSTEM_CONFIG"
-  echo "aborting..."
-  exit 1
-fi
-
-# ...and nowhere else.
-if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitconfig" ]]; then
-  echo "Global git config file found in unexpected location: $DESTINATION/$MINGW_DIR/etc/gitconfig"
+  if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitconfig" ]]; then
+    echo "System level git config file found in both locations"
+    echo "aborting..."
+    exit 1
+  fi
+else if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitconfig" ]]
+  SYSTEM_CONFIG="$DESTINATION/$MINGW_DIR/etc/gitconfig"
+else
+  echo "Could not locate system git config file"
   echo "aborting..."
   exit 1
 fi
@@ -100,19 +99,20 @@ git config --file "$SYSTEM_CONFIG" --unset http.sslCAInfo
 git config --file "$SYSTEM_CONFIG" http.schannelUseSSLCAInfo "false"
 
 # removing global gitattributes file
-echo "-- Removing global gitattributes which handles certain file extensions"
+echo "-- Removing system level gitattributes which handles certain file extensions"
 
-if [[ ! -f "$DESTINATION/etc/gitattributes" ]]; then
-  echo "Global git attributes file not found in expected location: $DESTINATION/etc/gitattributes"
-  echo "aborting..."
-  exit 1
+if [[ -f "$DESTINATION/etc/gitattributes" ]]; then
+  SYSTEM_GITATTRIBUTES="$DESTINATION/etc/gitattributes"
+
+  if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitattributes" ]]; then
+    echo "System level git attributes file found in both locations"
+    echo "aborting..."
+    exit 1
+  fi
+else if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitattributes" ]]
+  SYSTEM_GITATTRIBUTES="$DESTINATION/$MINGW_DIR/etc/gitattributes"
 fi
 
-if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitattributes" ]]; then
-  echo "Global git attributes file found in unexpected location: $DESTINATION/$MINGW_DIR/etc/gitattributes"
-  echo "aborting..."
-  exit 1
-fi
 rm "$DESTINATION/etc/gitattributes"
 
 echo "-- Removing legacy credential helpers"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -63,7 +63,7 @@ else
 fi
 
 
-SYSTEM_CONFIG="$DESTINATION/$MINGW_DIR/etc/gitconfig"
+SYSTEM_CONFIG="$DESTINATION/etc/gitconfig"
 
 echo "-- Setting some system configuration values"
 git config --file "$SYSTEM_CONFIG" core.symlinks "false"
@@ -87,7 +87,7 @@ git config --file "$SYSTEM_CONFIG" http.schannelUseSSLCAInfo "false"
 
 # removing global gitattributes file
 echo "-- Removing global gitattributes which handles certain file extensions"
-rm "$DESTINATION/$MINGW_DIR/etc/gitattributes"
+rm "$DESTINATION/etc/gitattributes"
 
 echo "-- Removing legacy credential helpers"
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-store.exe"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -86,9 +86,9 @@ git config --file "$SYSTEM_CONFIG" --unset http.sslCAInfo
 git config --file "$SYSTEM_CONFIG" http.schannelUseSSLCAInfo "false"
 
 # removing global gitattributes file
-rm "$DESTINATION/$MINGW_DIR/etc/gitattributes"
 echo "-- Removing global gitattributes which handles certain file extensions"
+rm "$DESTINATION/$MINGW_DIR/etc/gitattributes"
 
+echo "-- Removing legacy credential helpers"
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-store.exe"
 rm "$DESTINATION/$MINGW_DIR/bin/git-credential-wincred.exe"
-echo "-- Removing legacy credential helpers"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -70,7 +70,7 @@ if [[ -f "$DESTINATION/etc/gitconfig" ]]; then
     echo "aborting..."
     exit 1
   fi
-elif [[ -f "$DESTINATION/$MINGW_DIR/etc/gitconfig" ]]
+elif [[ -f "$DESTINATION/$MINGW_DIR/etc/gitconfig" ]]; then
   SYSTEM_CONFIG="$DESTINATION/$MINGW_DIR/etc/gitconfig"
 else
   echo "Could not locate system git config file"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -70,7 +70,7 @@ if [[ -f "$DESTINATION/etc/gitconfig" ]]; then
     echo "aborting..."
     exit 1
   fi
-else if [[ -f "$DESTINATION/$MINGW_DIR/etc/gitconfig" ]]
+elif [[ -f "$DESTINATION/$MINGW_DIR/etc/gitconfig" ]]
   SYSTEM_CONFIG="$DESTINATION/$MINGW_DIR/etc/gitconfig"
 else
   echo "Could not locate system git config file"


### PR DESCRIPTION
When shipping #310 we realized to late that the system gitconfig and gitattributes files in MinGit had been moved from `/mingw64/etc/` to just `/etc` in the backported Git for Windows release causing us to not be able to apply our custom gitconfig changes.

https://ci.appveyor.com/project/github-windows/dugite-native/builds/29448631/job/4xehkkqhbfy0g09c

<img width="929" alt="image" src="https://user-images.githubusercontent.com/634063/70573407-33724480-1ba2-11ea-8869-3505d2ee48f1.png">



@dscho As per :point_up: it seems that between `2.19.2.windows.3` and `2.19.2.windows.4` the system level gitconfig has moved

```
$ unzip -l MinGit-2.19.2.windows.3-64-bit.zip |grep -E 'git(config|attributes)'
      329  08-17-2019 20:54   mingw64/etc/gitattributes
      406  08-17-2019 20:54   mingw64/etc/gitconfig
$ unzip -l MinGit-2.19.2.windows.4-64-bit.zip |grep -E 'git(config|attributes)'
      329  11-23-2019 23:10   etc/gitattributes
      558  11-23-2019 23:10   etc/gitconfig
```

There doesn't seem to be any other relocations.

```diff
--- MinGit-2.19.2.windows.3-64-bit.zip.files    2019-12-10 23:17:39.000000000 +0100
+++ MinGit-2.19.2.windows.4-64-bit.zip.files    2019-12-10 23:17:48.000000000 +0100
@@ -9,6 +9,8 @@
 etc/bash.bash_logout
 etc/bash.bashrc
 etc/fstab
+etc/gitattributes
+etc/gitconfig
 etc/libexec-moved.txt
 etc/msystem
 etc/nsswitch.conf
@@ -64,8 +66,6 @@
 mingw64/bin/zlib1.dll
 mingw64/doc/git-credential-manager/LICENSE.txt
 mingw64/doc/git-credential-manager/README.md
-mingw64/etc/gitattributes
-mingw64/etc/gitconfig
 mingw64/lib/cmake/minizip-exports-release.cmake
 mingw64/lib/cmake/minizip-exports.cmake
 mingw64/lib/engines/4758ccaeay32.dl
```

@dscho I'm assuming this is because of https://github.com/git-for-windows/build-extra/commit/ab21cf29fea1a37e21cd60265a6af1191e055308 ? We're making provisions here to deal with it in dugite but I just wanted to put it on your radar in case there are any plans to move it back in a future version.