### PR TITLE
Skip including gitconfig file from Program Files

### DIFF
--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -98,6 +98,19 @@ git config --file "$SYSTEM_CONFIG" --unset http.sslCAInfo
 # details: https://github.com/dscho/git/blob/6152657e1a97c478df97d633c47469043b397519/Documentation/config.txt#L2135
 git config --file "$SYSTEM_CONFIG" http.schannelUseSSLCAInfo "false"
 
+# Git for Windows has started automatically including the config file
+# from c:\Program Files\Git\etc\gitconfig, see
+#
+# https://github.com/git-for-windows/build-extra/commit/475b4538803e6354ba19f334fea40446cf4fdc3f
+#
+# While the notion of being able to inherit some system level config values
+# is appealing it's also scary as we lose our isolation. The way the include
+# section is set up at the moment means that any config value in the Program Files
+# directory takes precedence over ours meaning that we might end up using the
+# openssl backend even though GitHub Desktop requires the schannel backend for
+# certificate bypass to work.
+git config --file "$SYSTEM_CONFIG" --remove-section include
+
 # removing global gitattributes file
 echo "-- Removing system level gitattributes which handles certain file extensions"
 


### PR DESCRIPTION
After an enlightening discussion with @dscho I've decided that we'll pull the `include` section from the system level git config that ships in dugite for now.

In versions of Git for Windows prior to 2.24.0 the Git config hierarchy looked something like this (h/t @dscho)

```
c:\ProgramData\Git\config < our system config < xdg_config < global < repo < command-line
```

In versions post 2.24.0 the hierarchy will instead look like this

```
c:\Program Files (x86)\Git\config < c:\Program Files\Git\config < our system config < xdg_config < global < repo < command-line
```

The `ProgramData` config was hard coded into Git for Windows but that's changes for the ProgramFiles location in 2.24.0 to be an include section in the system level config.

For 2.24.0 releases of Dugite we should most likely adopt this pattern such that _some_ config values from ProgramFiles\Git get included in our system level config but if we keep the section now we'll risk overriding config values that are important to the functionality of Desktop (such as http.sslBackend` and the LFS filter section).

So for the patch releases on the 2.19.x series we're gonna remove the include section which will ensure that we maintain the same behavior as previous patch releases.

Since we're a little strapped for time I'm planning on leaving this open for proper review but cherry pick it on top of a patch release branch and get that shipped asap.