### PR TITLE
Bump to Git 2.23.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,16 +40,16 @@ matrix:
       env:
         - TARGET_PLATFORM=win32
         - WIN_ARCH=64
-        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip
-        - GIT_FOR_WINDOWS_CHECKSUM=bd91db55bd95eaa80687df28877e2df8c8858a0266e9c67331cfddba2735f25c
+        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.23.0.windows.2/MinGit-2.23.0.windows.2-64-bit.zip
+        - GIT_FOR_WINDOWS_CHECKSUM=16085fb2bb5b3091d0c977b082c5fc632bbd59340bd4af325b6b662dc42e0227
         - GIT_LFS_CHECKSUM=5cbe0765d469bbb32548a86e92d5e8694f1e97df7d590552477c3fafdc6c82e1
     - os: linux
       language: c
       env:
         - TARGET_PLATFORM=win32
         - WIN_ARCH=32
-        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-32-bit.zip
-        - GIT_FOR_WINDOWS_CHECKSUM=652c05175553e25401e38c7e65467d92748fc5d577374c9587c09f5875d8937e
+        - GIT_FOR_WINDOWS_URL=https://github.com/git-for-windows/git/releases/download/v2.23.0.windows.2/MinGit-2.23.0.windows.2-32-bit.zip
+        - GIT_FOR_WINDOWS_CHECKSUM=aa96e6472b7b6f6c320fb24d0b90afa14d9ca38c8473b5832d5911ae92ee1e9a
         - GIT_LFS_CHECKSUM=f4f49e9261584711c337f566a62bd9645cc0e10cef4dc54de1e1e0d31a7b2f71
 compiler:
   - gcc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,13 +13,13 @@ environment:
   matrix:
     - TARGET_PLATFORM: win32
       WIN_ARCH: 64
-      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip
-      GIT_FOR_WINDOWS_CHECKSUM: bd91db55bd95eaa80687df28877e2df8c8858a0266e9c67331cfddba2735f25c
+      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.23.0.windows.2/MinGit-2.23.0.windows.2-64-bit.zip
+      GIT_FOR_WINDOWS_CHECKSUM: 16085fb2bb5b3091d0c977b082c5fc632bbd59340bd4af325b6b662dc42e0227
       GIT_LFS_CHECKSUM: 5cbe0765d469bbb32548a86e92d5e8694f1e97df7d590552477c3fafdc6c82e1
     - TARGET_PLATFORM: win32
       WIN_ARCH: 32
-      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-32-bit.zip
-      GIT_FOR_WINDOWS_CHECKSUM: 652c05175553e25401e38c7e65467d92748fc5d577374c9587c09f5875d8937e
+      GIT_FOR_WINDOWS_URL: https://github.com/git-for-windows/git/releases/download/v2.23.0.windows.2/MinGit-2.23.0.windows.2-32-bit.zip
+      GIT_FOR_WINDOWS_CHECKSUM: aa96e6472b7b6f6c320fb24d0b90afa14d9ca38c8473b5832d5911ae92ee1e9a
       GIT_LFS_CHECKSUM: f4f49e9261584711c337f566a62bd9645cc0e10cef4dc54de1e1e0d31a7b2f71
 build_script:
   - git submodule update --init --recursive

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,20 +1,20 @@
 {
   "git": {
-    "version": "v2.21.0",
+    "version": "v2.23.1",
     "packages": [
       {
         "platform": "windows",
         "arch": "amd64",
-        "filename": "MinGit-2.21.0-64-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-64-bit.zip",
-        "checksum": "bd91db55bd95eaa80687df28877e2df8c8858a0266e9c67331cfddba2735f25c"
+        "filename": "MinGit-2.23.0.windows.2-64-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.23.0.windows.2/MinGit-2.23.0.windows.2-64-bit.zip",
+        "checksum": "16085fb2bb5b3091d0c977b082c5fc632bbd59340bd4af325b6b662dc42e0227"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "filename": "MinGit-2.21.0-32-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/MinGit-2.21.0-32-bit.zip",
-        "checksum": "652c05175553e25401e38c7e65467d92748fc5d577374c9587c09f5875d8937e"
+        "filename": "MinGit-2.23.0.windows.2-32-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.23.0.windows.2/MinGit-2.23.0.windows.2-32-bit.zip",
+        "checksum": "aa96e6472b7b6f6c320fb24d0b90afa14d9ca38c8473b5832d5911ae92ee1e9a"
       }
     ]
   },

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -171,7 +171,7 @@ async function run() {
     const result = await octokit.pulls.get({
       owner,
       repo,
-      number: pullRequestId,
+      pull_number: pullRequestId,
     })
     const { title, number, user } = result.data
     const entry = ` - ${title} - #${number} via @${user.login}`

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -4,7 +4,7 @@ import rp from 'request-promise'
 // five targeted OS/arch combinations
 // two files for each targeted OS/arch
 // two checksum files for the previous
-const SUCCESSFUL_RELEASE_FILE_COUNT = 5 * 2 * 2
+const SUCCESSFUL_RELEASE_FILE_COUNT = 4 * 2 * 2
 
 process.on('unhandledRejection', reason => {
   console.log(reason)


### PR DESCRIPTION
Closes #303

[Git for Windows 2.23.0.windows.2](https://github.com/git-for-windows/git/releases/tag/v2.23.0.windows.2) and [Git 2.23.1](https://github.com/git/git/releases/tag/v2.23.1)

### TODO

- [x] ~~https://github.com/desktop/dugite-native/pull/313#issuecomment-566557787 ?~~
Punt until next upgrade