### PR TITLE
Change CI to use an older Xcode to build git for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
             arch: 32
     timeout-minutes: 20
     steps:
+      # We need to use Xcode 10.3 for maximum compatibility with older macOS
+      - name: Switch to Xcode 10.3
+        if: matrix.targetPlatform == 'macOS'
+        run: |
+          sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer/
+          # Delete the command line tools to make sure they don't get our builds
+          # messed up with macOS SDK 10.15 stuff.
+          sudo rm -rf /Library/Developer/CommandLineTools
       - uses: actions/checkout@v2
         with:
           submodules: recursive


### PR DESCRIPTION
I think building it with the latest Xcode version might cause some issues in older macOS. See desktop/desktop#11516