### PR TITLE
Generate arm64 builds of git and git-lfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
             friendlyName: macOS
             targetPlatform: macOS
             arch: arm64
+            go: 1.16.3
           - os: windows-2019
             friendlyName: Windows
             targetPlatform: win32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       matrix:
         os: [macos-10.15, windows-2019, ubuntu-18.04]
         arch: [32, 64]
+        go: [1.16.3]
         include:
           - os: macos-10.15
             friendlyName: macOS
@@ -61,6 +62,10 @@ jobs:
           submodules: recursive
           # Needed for script/package.sh to work
           fetch-depth: 0
+      - name: Use go ${{ matrix.go }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
       - name: Install dependencies
         run: npm install
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
           - os: macos-10.15
             friendlyName: macOS
             targetPlatform: macOS
+          - os: macos-10.15
+            friendlyName: macOS
+            targetPlatform: macOS
+            arch: arm64
           - os: windows-2019
             friendlyName: Windows
             targetPlatform: win32
@@ -44,9 +48,9 @@ jobs:
             arch: 32
     timeout-minutes: 20
     steps:
-      # We need to use Xcode 10.3 for maximum compatibility with older macOS
+      # We need to use Xcode 10.3 for maximum compatibility with older macOS (x64)
       - name: Switch to Xcode 10.3
-        if: matrix.targetPlatform == 'macOS'
+        if: matrix.targetPlatform == 'macOS' && matrix.arch == 64
         run: |
           sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer/
           # Delete the command line tools to make sure they don't get our builds
@@ -66,12 +70,22 @@ jobs:
       - name: Install extra dependencies for building Git on Ubuntu
         if: matrix.targetPlatform == 'ubuntu'
         run: sudo apt-get install libcurl4-openssl-dev libexpat1-dev gettext
-      - name: Build
+      - name: Build (except macOS arm64)
+        if: matrix.targetPlatform != 'macOS' || matrix.arch != arm64
         shell: bash
         run: script/build.sh
         env:
           TARGET_PLATFORM: ${{ matrix.targetPlatform }}
           TARGET_ARCH: ${{ matrix.arch }}
+      - name: Build (macOS arm64)
+        if: matrix.targetPlatform == 'macOS' && matrix.arch == arm64
+        shell: bash
+        run: script/build.sh
+        env:
+          TARGET_PLATFORM: ${{ matrix.targetPlatform }}
+          TARGET_ARCH: ${{ matrix.arch }}
+          # Needed for macOS arm64 until hosted macos-11.0 runners become available
+          SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
       - name: Package
         shell: bash
         run: script/package.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,14 @@ jobs:
         if: matrix.targetPlatform == 'ubuntu'
         run: sudo apt-get install libcurl4-openssl-dev libexpat1-dev gettext
       - name: Build (except macOS arm64)
-        if: matrix.targetPlatform != 'macOS' || matrix.arch != arm64
+        if: matrix.targetPlatform != 'macOS' || matrix.arch != 'arm64'
         shell: bash
         run: script/build.sh
         env:
           TARGET_PLATFORM: ${{ matrix.targetPlatform }}
           TARGET_ARCH: ${{ matrix.arch }}
       - name: Build (macOS arm64)
-        if: matrix.targetPlatform == 'macOS' && matrix.arch == arm64
+        if: matrix.targetPlatform == 'macOS' && matrix.arch == 'arm64'
         shell: bash
         run: script/build.sh
         env:

--- a/dependencies.json
+++ b/dependencies.json
@@ -40,28 +40,5 @@
         "checksum": "0e13b411ca6c2b2cfb3d82b67ae747ca5d055734d0ab2030d0823fc37ad48902"
       }
     ]
-  },
-  "smimesign": {
-    "version": "0.0.6",
-    "files": [
-      {
-        "platform": "darwin",
-        "arch": "amd64",
-        "name": "smimesign-0.0.6-macos.tgz",
-        "checksum": "771790f685176b132cb287302a9374120184f7f7973038a0232efee145781906"
-      },
-      {
-        "platform": "windows",
-        "arch": "amd64",
-        "name": "smimesign-windows-amd64-0.0.6.zip",
-        "checksum": "2a2f946e31f2d74eadcdcd97b7bfc69298cee2f11cf7cb03c604d28fa1b34cd3"
-      },
-      {
-        "platform": "windows",
-        "arch": "x86",
-        "name": "smimesign-windows-386-0.0.6.zip",
-        "checksum": "9a13d00aa02c0a5d277c030297d09f10a467f31e6740f1520a08e09a23046323"
-      }
-    ]
   }
 }

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -76,7 +76,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   git clone -b "v$GIT_LFS_VERSION" "https://github.com/git-lfs/git-lfs"
   (
     cd git-lfs
-    GO_GENERATE_STRING='$(GO) generate github.com\/git-lfs\/git-lfs\/commands'
+    GO_GENERATE_STRING="\$(GO) generate github.com\/git-lfs\/git-lfs\/commands"
     sed -i -e "s/$GO_GENERATE_STRING/GOARCH= $GO_GENERATE_STRING/" Makefile
     make GOARCH="$GOARCH" CGO_CFLAGS="-mmacosx-version-min=$MACOSX_BUILD_VERSION" CGO_LDFLAGS="-mmacosx-version-min=$MACOSX_BUILD_VERSION" BUILTIN_LD_FLAGS="-linkmode external"
   )

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -76,8 +76,15 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   git clone -b "v$GIT_LFS_VERSION" "https://github.com/git-lfs/git-lfs"
   (
     cd git-lfs
+
+    # HACK: When cross-compiling, there seems to be an issue when git-lfs attempts
+    # to generate the manpage contents, and it seems that preffixing that command
+    # with `GOARCH=` to use the host architecture fixes the issue.
+    # This hack can be removed once the issue is fixed via the PR
+    # https://github.com/git-lfs/git-lfs/pull/4492 or some other solution.
     GO_GENERATE_STRING="\$(GO) generate github.com\/git-lfs\/git-lfs\/commands"
     sed -i -e "s/$GO_GENERATE_STRING/GOARCH= $GO_GENERATE_STRING/" Makefile
+
     make GOARCH="$GOARCH" CGO_CFLAGS="-mmacosx-version-min=$MACOSX_BUILD_VERSION" CGO_LDFLAGS="-mmacosx-version-min=$MACOSX_BUILD_VERSION" BUILTIN_LD_FLAGS="-linkmode external"
   )
   GIT_LFS_BINARY_PATH="git-lfs/bin/git-lfs"

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -76,6 +76,8 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   git clone -b "v$GIT_LFS_VERSION" "https://github.com/git-lfs/git-lfs"
   (
     cd git-lfs
+    GO_GENERATE_STRING='$(GO) generate github.com\/git-lfs\/git-lfs\/commands'
+    sed -i -e "s/$GO_GENERATE_STRING/GOARCH= $GO_GENERATE_STRING/" Makefile
     make GOARCH="$GOARCH" CGO_CFLAGS="-mmacosx-version-min=$MACOSX_BUILD_VERSION" CGO_LDFLAGS="-mmacosx-version-min=$MACOSX_BUILD_VERSION" BUILTIN_LD_FLAGS="-linkmode external"
   )
   GIT_LFS_BINARY_PATH="git-lfs/bin/git-lfs"

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -7,7 +7,7 @@ export default class GenerateReleaseNotes {
   // five targeted OS/arch combinations
   // two files for each targeted OS/arch
   // two checksum files for the previous
-  private SUCCESSFUL_RELEASE_FILE_COUNT = 4 * 2 * 2
+  private SUCCESSFUL_RELEASE_FILE_COUNT = 5 * 2 * 2
   private args = process.argv.slice(2)
   private expectedArgs = [
     {

--- a/script/package.sh
+++ b/script/package.sh
@@ -37,8 +37,9 @@ if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
   GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.tar.gz"
   LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.lzma"
 elif [ "$TARGET_PLATFORM" == "macOS" ]; then
-  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS.lzma"
+  if [ "$TARGET_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="arm64"; fi
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$ARCH.lzma"
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
   if [ "$TARGET_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="x86"; fi
   GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.tar.gz"


### PR DESCRIPTION
This PR fixes the build-macos script and our CI workflow to allow generating macOS builds of git and git-lfs for arm64.

In order to do that there are a couple of "hacks":
- Use `DEVELOPER_CLFAGS` to "inject" our `-target` cflag to specify the target architecture.
- Fix git-lfs Makefile to prevent it from failing when cross-compiling. See https://github.com/git-lfs/git-lfs/pull/4492 for more details.