### PR TITLE
add 386, arm, and arm64 to ubuntu buildscripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-10.15, windows-2019, ubuntu-18.04]
-        arch: [32, 64]
+        arch: [x86, x64]
         go: [1.16.3]
         include:
           - os: macos-10.15
@@ -45,14 +45,14 @@ jobs:
             targetPlatform: ubuntu
         exclude:
           - os: macos-10.15
-            arch: 32
+            arch: x86
           - os: ubuntu-18.04
-            arch: 32
+            arch: x86
     timeout-minutes: 20
     steps:
       # We need to use Xcode 10.3 for maximum compatibility with older macOS (x64)
       - name: Switch to Xcode 10.3
-        if: matrix.targetPlatform == 'macOS' && matrix.arch == 64
+        if: matrix.targetPlatform == 'macOS' && matrix.arch == 'x64'
         run: |
           sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer/
           # Delete the command line tools to make sure they don't get our builds
@@ -73,8 +73,8 @@ jobs:
         run: npm run prettier
       - name: Build tools
         run: npm run check
-      - name: Install extra dependencies for building Git on Ubuntu
-        if: matrix.targetPlatform == 'ubuntu'
+      - name: Install extra dependencies for building Git on Ubuntu (x64)
+        if: matrix.targetPlatform == 'ubuntu' && matrix.arch == 'x64'
         run: |
           sudo apt-get update
           sudo apt-get install libcurl4-openssl-dev libexpat1-dev gettext

--- a/dependencies.json
+++ b/dependencies.json
@@ -28,6 +28,24 @@
         "checksum": "6a4e6bd7d06d5c024bc70c8ee8c9da143ffc37d2646e252a17a6126d30cdebc1"
       },
       {
+        "platform": "linux",
+        "arch": "x86",
+        "name": "git-lfs-linux-386-v3.3.0.tar.gz",
+        "checksum": "14415ebafc3ace60f178cd69d4f2e0ed42dbbf32cb2aba80e46ec3c8f7c1401f"
+      },
+      {
+        "platform": "linux",
+        "arch": "arm64",
+        "name": "git-lfs-linux-arm64-v3.3.0.tar.gz",
+        "checksum": "e97c477981a9b6a40026cadc1bf005541d973fc32df2de2f398643b15df6b5c6"
+      },
+      {
+        "platform": "linux",
+        "arch": "arm",
+        "name": "git-lfs-linux-arm-v3.3.0.tar.gz",
+        "checksum": "df8b24cf7ff6a2f105dd1a3d0a4990c53980272ea94da67d854921e21bc5444c"
+      },
+      {
         "platform": "windows",
         "arch": "x86",
         "name": "git-lfs-windows-386-v3.3.0.zip",

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -7,7 +7,7 @@ set -eu -o pipefail
 
 MACOSX_BUILD_VERSION="10.9"
 
-if [ "$TARGET_ARCH" = "64" ]; then
+if [ "$TARGET_ARCH" = "x64" ]; then
   HOST_CPU=x86_64
   TARGET_CFLAGS="-target x86_64-apple-darwin"
   GOARCH=amd64

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -20,15 +20,17 @@ if [[ -z "${CURL_INSTALL_DIR}" ]]; then
   exit 1
 fi
 
-if [ "$TARGET_ARCH" = "64" ]; then
-  DEPENDENCY_ARCH="amd64"
-else
-  DEPENDENCY_ARCH="x86"
-fi
+case "$TARGET_ARCH" in
+  "x64") DEPENDENCY_ARCH="amd64" ;;
+  "arm64") DEPENDENCY_ARCH="arm64" ;;
+  "arm") DEPENDENCY_ARCH="arm" ;;
+  *) DEPENDENCY_ARCH="x86" ;;
+esac
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 GIT_LFS_VERSION="$(jq --raw-output '.["git-lfs"].version[1:]' dependencies.json)"
 GIT_LFS_CHECKSUM="$(jq --raw-output ".\"git-lfs\".files[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"linux\") | .checksum" dependencies.json)"
+GIT_LFS_FILENAME="$(jq --raw-output ".\"git-lfs\".files[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"linux\") | .name" dependencies.json)"
 
 # shellcheck source=script/compute-checksum.sh
 source "$CURRENT_DIR/compute-checksum.sh"
@@ -72,7 +74,7 @@ DESTDIR="$DESTINATION" \
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.tar.gz
-  GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz"
+  GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/${GIT_LFS_FILENAME}"
   echo "-- Downloading from $GIT_LFS_URL"
   curl -sL -o $GIT_LFS_FILE "$GIT_LFS_URL"
   COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -10,7 +10,7 @@ if [[ -z "${DESTINATION}" ]]; then
   exit 1
 fi
 
-if [ "$TARGET_ARCH" = "64" ]; then
+if [ "$TARGET_ARCH" = "x64" ]; then
   DEPENDENCY_ARCH="amd64"
   MINGW_DIR="mingw64"
 else
@@ -20,6 +20,7 @@ fi
 
 GIT_LFS_VERSION=$(jq --raw-output ".[\"git-lfs\"].version[1:]" dependencies.json)
 GIT_LFS_CHECKSUM="$(jq --raw-output ".\"git-lfs\".files[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"windows\") | .checksum" dependencies.json)"
+GIT_LFS_FILENAME="$(jq --raw-output ".\"git-lfs\".files[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"windows\") | .name" dependencies.json)"
 GIT_FOR_WINDOWS_URL=$(jq --raw-output ".git.packages[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"windows\") | .url" dependencies.json)
 GIT_FOR_WINDOWS_CHECKSUM=$(jq --raw-output ".git.packages[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"windows\") | .checksum" dependencies.json)
 
@@ -47,8 +48,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   # download Git LFS, verify its the right contents, and unpack it
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.zip
-  if [ "$TARGET_ARCH" -eq "64" ]; then GIT_LFS_ARCH="amd64"; else GIT_LFS_ARCH="386"; fi
-  GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-windows-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.zip"
+  GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/${GIT_LFS_FILENAME}"
   echo "-- Downloading from $GIT_LFS_URL"
   curl -sL -o $GIT_LFS_FILE "$GIT_LFS_URL"
   COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)

--- a/script/package.sh
+++ b/script/package.sh
@@ -34,16 +34,14 @@ if ! [ -d "$DESTINATION" ]; then
 fi
 
 if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
-  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.lzma"
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu-$TARGET_ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu-$TARGET_ARCH.lzma"
 elif [ "$TARGET_PLATFORM" == "macOS" ]; then
-  if [ "$TARGET_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="arm64"; fi
-  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$ARCH.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$ARCH.lzma"
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$TARGET_ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$TARGET_ARCH.lzma"
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
-  if [ "$TARGET_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="x86"; fi
-  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.lzma"
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$TARGET_ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$TARGET_ARCH.lzma"
 else
   echo "Unable to package Git for platform $TARGET_PLATFORM"
   exit 1

--- a/script/update-git-lfs.ts
+++ b/script/update-git-lfs.ts
@@ -27,6 +27,12 @@ function getArch(fileName: string) {
   if (fileName.match(/-386-/)) {
     return 'x86'
   }
+  if (fileName.match(/-arm64-/)) {
+    return 'arm64'
+  }
+  if (fileName.match(/-arm-/)) {
+    return 'arm'
+  }
 
   throw new Error(`Unable to find arch for file: ${fileName}`)
 }
@@ -82,6 +88,9 @@ async function run(): Promise<boolean> {
 
   const files = [
     `git-lfs-linux-amd64-${version}.tar.gz`,
+    `git-lfs-linux-386-${version}.tar.gz`,
+    `git-lfs-linux-arm64-${version}.tar.gz`,
+    `git-lfs-linux-arm-${version}.tar.gz`,
     `git-lfs-windows-386-${version}.zip`,
     `git-lfs-windows-amd64-${version}.zip`,
   ]


### PR DESCRIPTION
current use of 64 and 32 in github actions is unaffected and will function as before

added arm, and arm64 as acceptable TARGET_ARCH options

this allows for making local builds of dugite-native on arm/arm64 hardware using the same buildscripts used in the github actions.
future changes may allow for building through github actions as well using cross compilation (or self hosted runner, see below)