### PR TITLE
Bump to 2.36.0

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,20 +1,20 @@
 {
   "git": {
-    "version": "v2.35.3",
+    "version": "v2.36.0",
     "packages": [
       {
         "platform": "windows",
         "arch": "amd64",
-        "filename": "MinGit-2.35.3-64-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.35.3.windows.1/MinGit-2.35.3-64-bit.zip",
-        "checksum": "9b88c81ad796acf9969825e8736b953cb0e0bfb4717be57fd59336ae94d521e4"
+        "filename": "MinGit-2.36.0-64-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.36.0.windows.1/MinGit-2.36.0-64-bit.zip",
+        "checksum": "0c6611fc04b9b111777a4f219e198bded07fea80fb14dedb01ebbcc231480986"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "filename": "MinGit-2.35.3-32-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.35.3.windows.1/MinGit-2.35.3-32-bit.zip",
-        "checksum": "1ad43122a8a7dc1633beeabcfa14aec5c35c211be8f3594431046ce3e60fc542"
+        "filename": "MinGit-2.36.0-32-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.36.0.windows.1/MinGit-2.36.0-32-bit.zip",
+        "checksum": "8c0d78619273116c7d76ca8ec1e5322ba3a315a113acafabcbd9febfb2dc493c"
       }
     ]
   },


### PR DESCRIPTION
Bumps git to 2.36.0 and git for windows to v2.36.0.windows.1 