### PR TITLE
Bump git to 2.39.1 and git-lfs to 3.3.0

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,20 +1,20 @@
 {
   "git": {
-    "version": "v2.35.5",
+    "version": "v2.39.0",
     "packages": [
       {
         "platform": "windows",
         "arch": "amd64",
-        "filename": "MinGit-2.35.5.windows.1-64-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.35.5.windows.1/MinGit-2.35.5.windows.1-64-bit.zip",
-        "checksum": "5ef1ac6d0fce8302b5b5268aee676a8b73f9b2806c3b5acca73e258577117c64"
+        "filename": "MinGit-2.39.0.2-64-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.39.0.windows.2/MinGit-2.39.0.2-64-bit.zip",
+        "checksum": "771e7bef1b672e3f63b18b8c4a62d626c8f47c41390a745f313758c0b6ae4d63"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "filename": "MinGit-2.35.5.windows.1-32-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.35.5.windows.1/MinGit-2.35.5.windows.1-32-bit.zip",
-        "checksum": "8f328cf886a1b9e6bb09b84db325d3033f3fd24c179de2180808683759459dc0"
+        "filename": "MinGit-2.39.0.2-32-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.39.0.windows.2/MinGit-2.39.0.2-32-bit.zip",
+        "checksum": "a5ac14121bb0fe879355f58db15aae41205046b7cd1832df40d1e784aa8e1c70"
       }
     ]
   },

--- a/dependencies.json
+++ b/dependencies.json
@@ -19,25 +19,25 @@
     ]
   },
   "git-lfs": {
-    "version": "v3.1.4",
+    "version": "v3.3.0",
     "files": [
       {
         "platform": "linux",
         "arch": "amd64",
-        "name": "git-lfs-linux-amd64-v3.1.4.tar.gz",
-        "checksum": "f97f3e40261d872a246f6fb2c96adf132f96c1428f70b4d0e5a644f98481fb76"
+        "name": "git-lfs-linux-amd64-v3.3.0.tar.gz",
+        "checksum": "6a4e6bd7d06d5c024bc70c8ee8c9da143ffc37d2646e252a17a6126d30cdebc1"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "name": "git-lfs-windows-386-v3.1.4.zip",
-        "checksum": "86ecf57cf47abfd63f1788005ee69f366ce6325ad2f720ee68efd4ac33e26057"
+        "name": "git-lfs-windows-386-v3.3.0.zip",
+        "checksum": "81fd4b01719e1e0ccf347596293f19a07fba8573c6aee1e1521b2932d9b6179d"
       },
       {
         "platform": "windows",
         "arch": "amd64",
-        "name": "git-lfs-windows-amd64-v3.1.4.zip",
-        "checksum": "76c27740e41b7bce35d8504357dd2962042a821b40a6df7d0dd4184ae7d7839f"
+        "name": "git-lfs-windows-amd64-v3.3.0.zip",
+        "checksum": "1df5874f22c35c679159f0aaf9e24333051f52768eade0204d22200b79141743"
       }
     ]
   }

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -79,7 +79,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/libexec/git-core"
-    tar -xvf $GIT_LFS_FILE -C "$SUBFOLDER" --exclude='*.sh' --exclude="*.md"
+    tar -xvf $GIT_LFS_FILE -C "$SUBFOLDER" --strip-components=1 --exclude='*.sh' --exclude="*.md"
 
     if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
       echo "After extracting Git LFS the file was not found under libexec/git-core/"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -e -x
 #
 # Compiling Git for Linux and bundling Git LFS from upstream.
 #

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e -x
+#!/bin/bash -e
 #
 # Compiling Git for Linux and bundling Git LFS from upstream.
 #


### PR DESCRIPTION
Bumps git to 2.39.1, git for windows to v2.39.1.windows.1 and git-lfs to 3.3.0.