### PR TITLE
Bump to 2.39.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, windows-2019, ubuntu-18.04]
+        os: [macos-10.15, windows-2019, ubuntu-22.04]
         arch: [32, 64]
         go: [1.16.3]
         include:
@@ -40,13 +40,13 @@ jobs:
           - os: windows-2019
             friendlyName: Windows
             targetPlatform: win32
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             friendlyName: Linux
             targetPlatform: ubuntu
         exclude:
           - os: macos-10.15
             arch: 32
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             arch: 32
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-10.15, windows-2019, ubuntu-18.04]
-        arch: [x86, x64]
+        arch: [32, 64]
         go: [1.16.3]
         include:
           - os: macos-10.15
@@ -43,22 +43,16 @@ jobs:
           - os: ubuntu-18.04
             friendlyName: Linux
             targetPlatform: ubuntu
-          - os: ubuntu-18.04
-            friendlyName: Linux
-            targetPlatform: ubuntu
-            arch: arm64
-          - os: ubuntu-18.04
-            friendlyName: Linux
-            targetPlatform: ubuntu
-            arch: arm
         exclude:
           - os: macos-10.15
-            arch: x86
+            arch: 32
+          - os: ubuntu-18.04
+            arch: 32
     timeout-minutes: 20
     steps:
       # We need to use Xcode 10.3 for maximum compatibility with older macOS (x64)
       - name: Switch to Xcode 10.3
-        if: matrix.targetPlatform == 'macOS' && matrix.arch == 'x64'
+        if: matrix.targetPlatform == 'macOS' && matrix.arch == 64
         run: |
           sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer/
           # Delete the command line tools to make sure they don't get our builds
@@ -79,35 +73,11 @@ jobs:
         run: npm run prettier
       - name: Build tools
         run: npm run check
-      - name: Install extra dependencies for building Git on Ubuntu (x64)
-        if: matrix.targetPlatform == 'ubuntu' && matrix.arch == 'x64'
+      - name: Install extra dependencies for building Git on Ubuntu
+        if: matrix.targetPlatform == 'ubuntu'
         run: |
           sudo apt-get update
           sudo apt-get install libcurl4-openssl-dev libexpat1-dev gettext
-      - name: Install extra dependencies for building Git on Ubuntu (x86)
-        if: matrix.targetPlatform == 'ubuntu' && matrix.arch == 'x86'
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get install gcc-i686-linux-gnu binutils-i686-gnu libcurl4-openssl-dev:i386 libssl-dev:i386 zlib1g-dev:i386 gettext
-      - name: Install extra dependencies for building Git on Ubuntu (arm64)
-        if: matrix.targetPlatform == 'ubuntu' && matrix.arch == 'arm64'
-        run: |
-          sudo sed -i "s/^deb/deb [arch=amd64,i386]/g" /etc/apt/sources.list
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ $(lsb_release -s -c) main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ $(lsb_release -s -c)-updates main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
-          sudo apt-get install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libcurl4-openssl-dev:arm64 libssl-dev:arm64 zlib1g-dev:arm64 gettext
-      - name: Install extra dependencies for building Git on Ubuntu (arm)
-        if: matrix.targetPlatform == 'ubuntu' && matrix.arch == 'arm'
-        run: |
-          sudo sed -i "s/^deb/deb [arch=amd64,i386]/g" /etc/apt/sources.list
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ $(lsb_release -s -c) main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ $(lsb_release -s -c)-updates main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
-          sudo dpkg --add-architecture armhf
-          sudo apt-get update
-          sudo apt-get install gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libcurl4-openssl-dev:armhf libssl-dev:armhf zlib1g-dev:armhf gettext
       - name: Build (except macOS arm64)
         if: matrix.targetPlatform != 'macOS' || matrix.arch != 'arm64'
         shell: bash

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,20 +1,20 @@
 {
   "git": {
-    "version": "v2.39.2",
+    "version": "v2.39.3",
     "packages": [
       {
         "platform": "windows",
         "arch": "amd64",
-        "filename": "MinGit-2.39.2-64-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.39.2.windows.1/MinGit-2.39.2-64-bit.zip",
-        "checksum": "a53b90a42d9a5e3ac992f525b5805c4dbb8a013b09a32edfdcf9a551fd8cfe2d"
+        "filename": "MinGit-2.39.3.windows.1-64-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.39.3.windows.1/MinGit-2.39.3.windows.1-64-bit.zip",
+        "checksum": "ffc5d2213ff567d35c15f3916d54f1d39a5c34e0ce70aa2450ab5b7e0551e2f8"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "filename": "MinGit-2.39.2-32-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.39.2.windows.1/MinGit-2.39.2-32-bit.zip",
-        "checksum": "f2027f51f8b12e5bd3c94782edddcfe277e26a3fc7c014707a72b04714f3b90f"
+        "filename": "MinGit-2.39.3.windows.1-32-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.39.3.windows.1/MinGit-2.39.3.windows.1-32-bit.zip",
+        "checksum": "ac4c461ba7dd682e0c35f9675e96de3e8969938f5a4fb77c6f522b7655f834f4"
       }
     ]
   },

--- a/dependencies.json
+++ b/dependencies.json
@@ -28,24 +28,6 @@
         "checksum": "6a4e6bd7d06d5c024bc70c8ee8c9da143ffc37d2646e252a17a6126d30cdebc1"
       },
       {
-        "platform": "linux",
-        "arch": "x86",
-        "name": "git-lfs-linux-386-v3.3.0.tar.gz",
-        "checksum": "14415ebafc3ace60f178cd69d4f2e0ed42dbbf32cb2aba80e46ec3c8f7c1401f"
-      },
-      {
-        "platform": "linux",
-        "arch": "arm64",
-        "name": "git-lfs-linux-arm64-v3.3.0.tar.gz",
-        "checksum": "e97c477981a9b6a40026cadc1bf005541d973fc32df2de2f398643b15df6b5c6"
-      },
-      {
-        "platform": "linux",
-        "arch": "arm",
-        "name": "git-lfs-linux-arm-v3.3.0.tar.gz",
-        "checksum": "df8b24cf7ff6a2f105dd1a3d0a4990c53980272ea94da67d854921e21bc5444c"
-      },
-      {
         "platform": "windows",
         "arch": "x86",
         "name": "git-lfs-windows-386-v3.3.0.zip",

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -7,7 +7,7 @@ set -eu -o pipefail
 
 MACOSX_BUILD_VERSION="10.9"
 
-if [ "$TARGET_ARCH" = "x64" ]; then
+if [ "$TARGET_ARCH" = "64" ]; then
   HOST_CPU=x86_64
   TARGET_CFLAGS="-target x86_64-apple-darwin"
   GOARCH=amd64

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -10,7 +10,7 @@ if [[ -z "${DESTINATION}" ]]; then
   exit 1
 fi
 
-if [ "$TARGET_ARCH" = "x64" ]; then
+if [ "$TARGET_ARCH" = "64" ]; then
   DEPENDENCY_ARCH="amd64"
   MINGW_DIR="mingw64"
 else
@@ -20,7 +20,6 @@ fi
 
 GIT_LFS_VERSION=$(jq --raw-output ".[\"git-lfs\"].version[1:]" dependencies.json)
 GIT_LFS_CHECKSUM="$(jq --raw-output ".\"git-lfs\".files[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"windows\") | .checksum" dependencies.json)"
-GIT_LFS_FILENAME="$(jq --raw-output ".\"git-lfs\".files[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"windows\") | .name" dependencies.json)"
 GIT_FOR_WINDOWS_URL=$(jq --raw-output ".git.packages[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"windows\") | .url" dependencies.json)
 GIT_FOR_WINDOWS_CHECKSUM=$(jq --raw-output ".git.packages[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"windows\") | .checksum" dependencies.json)
 
@@ -48,7 +47,8 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   # download Git LFS, verify its the right contents, and unpack it
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.zip
-  GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/${GIT_LFS_FILENAME}"
+  if [ "$TARGET_ARCH" -eq "64" ]; then GIT_LFS_ARCH="amd64"; else GIT_LFS_ARCH="386"; fi
+  GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-windows-${GIT_LFS_ARCH}-v${GIT_LFS_VERSION}.zip"
   echo "-- Downloading from $GIT_LFS_URL"
   curl -sL -o $GIT_LFS_FILE "$GIT_LFS_URL"
   COMPUTED_SHA256=$(compute_checksum $GIT_LFS_FILE)

--- a/script/check-static-linking.sh
+++ b/script/check-static-linking.sh
@@ -11,7 +11,7 @@ check_static_linking_file() {
 
   # ermagherd there's two whitespace characters between 'LSB' and 'executable'
   # when running this on Travis - why is everything so terrible?
-  if file "$1" | grep -q 'ELF [36][24]-bit LSB'; then
+  if file "$1" | grep -q 'ELF 64-bit LSB'; then
     if readelf -d "$1" | grep -q 'Shared library'; then
       echo "File: $file"
       # this is done twice rather than storing in a bash variable because

--- a/script/package.sh
+++ b/script/package.sh
@@ -34,14 +34,16 @@ if ! [ -d "$DESTINATION" ]; then
 fi
 
 if [ "$TARGET_PLATFORM" == "ubuntu" ]; then
-  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu-$TARGET_ARCH.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu-$TARGET_ARCH.lzma"
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-ubuntu.lzma"
 elif [ "$TARGET_PLATFORM" == "macOS" ]; then
-  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$TARGET_ARCH.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$TARGET_ARCH.lzma"
+  if [ "$TARGET_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="arm64"; fi
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-macOS-$ARCH.lzma"
 elif [ "$TARGET_PLATFORM" == "win32" ]; then
-  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$TARGET_ARCH.tar.gz"
-  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$TARGET_ARCH.lzma"
+  if [ "$TARGET_ARCH" -eq "64" ]; then ARCH="x64"; else ARCH="x86"; fi
+  GZIP_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.tar.gz"
+  LZMA_FILE="dugite-native-$VERSION-$BUILD_HASH-windows-$ARCH.lzma"
 else
   echo "Unable to package Git for platform $TARGET_PLATFORM"
   exit 1

--- a/script/update-git-lfs.ts
+++ b/script/update-git-lfs.ts
@@ -27,12 +27,6 @@ function getArch(fileName: string) {
   if (fileName.match(/-386-/)) {
     return 'x86'
   }
-  if (fileName.match(/-arm64-/)) {
-    return 'arm64'
-  }
-  if (fileName.match(/-arm-/)) {
-    return 'arm'
-  }
 
   throw new Error(`Unable to find arch for file: ${fileName}`)
 }
@@ -88,9 +82,6 @@ async function run(): Promise<boolean> {
 
   const files = [
     `git-lfs-linux-amd64-${version}.tar.gz`,
-    `git-lfs-linux-386-${version}.tar.gz`,
-    `git-lfs-linux-arm64-${version}.tar.gz`,
-    `git-lfs-linux-arm-${version}.tar.gz`,
     `git-lfs-windows-386-${version}.zip`,
     `git-lfs-windows-amd64-${version}.zip`,
   ]


### PR DESCRIPTION
Bumps Git to 2.39.3 and Git for Windows to v2.39.3.windows.1

EDIT: 
- Linux builds were not being picked up by action.
- Found that on April 3rd, [actions no longer supports ubuntu-18.04](https://github.com/actions/runner-images/issues/6002)
- Tried `ubuntu-latest` which should be `ubuntu-22.04` and `ubuntu-20.04` and they both failed.
- Reverted [#414 - Add ARM64, ARM32, and x86 Linux Builds](https://github.com/desktop/dugite-native/pull/414) and updated to `ubuntu-22.04` and build succeeds. We will have to revisit Arm64 builds for linux.