### PR TITLE
Bump macOS CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, windows-2019, ubuntu-20.04]
+        os: [macos-11, windows-2019, ubuntu-20.04]
         arch: [x86, x64]
         go: [1.16.3]
         include:
-          - os: macos-10.15
+          - os: macos-11
             friendlyName: macOS
             targetPlatform: macOS
-          - os: macos-10.15
+          - os: macos-11
             friendlyName: macOS
             targetPlatform: macOS
             arch: arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       # We need to use Xcode 11.7 for maximum compatibility with older macOS (x64)
       - name: Switch to Xcode 11.7
-        if: matrix.targetPlatform == 'macOS'
+        if: matrix.targetPlatform == 'macOS' && matrix.arch == 'x64'
         run: |
           sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer/
           # Delete the command line tools to make sure they don't get our builds
@@ -122,8 +122,6 @@ jobs:
         env:
           TARGET_PLATFORM: ${{ matrix.targetPlatform }}
           TARGET_ARCH: ${{ matrix.arch }}
-          # Needed for macOS arm64 until hosted macos-11.0 runners become available
-          SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
       - name: Package
         shell: bash
         run: script/package.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             targetPlatform: ubuntu
             arch: arm
         exclude:
-          - os: macos-10.15
+          - os: macos-11
             arch: x86
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,6 @@ jobs:
         if: matrix.targetPlatform == 'macOS' && matrix.arch == 'x64'
         run: |
           sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer/
-          # Delete the command line tools to make sure they don't get our builds
-          # messed up with macOS SDK 11 stuff.
-          sudo rm -rf /Library/Developer/CommandLineTools
       - uses: actions/checkout@v2
         with:
           submodules: recursive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,13 @@ jobs:
             arch: x86
     timeout-minutes: 20
     steps:
-      # We need to use Xcode 10.3 for maximum compatibility with older macOS (x64)
-      - name: Switch to Xcode 10.3
+      # We need to use Xcode 11.7 for maximum compatibility with older macOS (x64)
+      - name: Switch to Xcode 11.7
         if: matrix.targetPlatform == 'macOS' && matrix.arch == 'x64'
         run: |
-          sudo xcode-select -s /Applications/Xcode_10.3.app/Contents/Developer/
+          sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer/
           # Delete the command line tools to make sure they don't get our builds
-          # messed up with macOS SDK 10.15 stuff.
+          # messed up with macOS SDK 11 stuff.
           sudo rm -rf /Library/Developer/CommandLineTools
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,12 @@ jobs:
     steps:
       # We need to use Xcode 11.7 for maximum compatibility with older macOS (x64)
       - name: Switch to Xcode 11.7
-        if: matrix.targetPlatform == 'macOS' && matrix.arch == 'x64'
+        if: matrix.targetPlatform == 'macOS'
         run: |
           sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer/
+          # Delete the command line tools to make sure they don't get our builds
+          # messed up with macOS SDK 11 stuff.
+          sudo rm -rf /Library/Developer/CommandLineTools
       - uses: actions/checkout@v2
         with:
           submodules: recursive


### PR DESCRIPTION
It seems [macos-10.15 runners were deprecated & removed months ago](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22) (still don’t understand how it worked since then) and on Friday whatever was left got finally removed.

This PR bumps dugite’s runners to a more recent macOS version. I’m mainly concerned about the fact that [we relied on an older Xcode version to maximize compatibility with older macOS versions](https://github.com/desktop/dugite-native/blob/7082cf8c53e544fd74824881d9c61bb580f972c2/.github/workflows/ci.yml#L59-L66) and that won’t be possible now (at least not with the same version, AFAIK).