### PR TITLE
Fixes for release notes script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,8 @@ jobs:
     needs: [build, shellcheck]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
 

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -163,7 +163,7 @@ export default class GenerateReleaseNotes {
       const match = mergeCommitRegex.exec(mergeCommitMessage)
       if (match != null && match.length === 2) {
         const num = parseInt(match[1])
-        if (num != NaN) {
+        if (!Number.isNaN(num)) {
           pullRequestIds.push(num)
         }
       }

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -4,10 +4,10 @@ import * as fs from 'fs'
 import { Octokit } from '@octokit/rest'
 
 export default class GenerateReleaseNotes {
-  // five targeted OS/arch combinations
+  // Eight targeted OS/arch combinations
   // two files for each targeted OS/arch
   // two checksum files for the previous
-  private SUCCESSFUL_RELEASE_FILE_COUNT = 5 * 2 * 2
+  private SUCCESSFUL_RELEASE_FILE_COUNT = 8 * 2 * 2
   private args = process.argv.slice(2)
   private expectedArgs = [
     {


### PR DESCRIPTION
This addresses a CI failure I found when pushing a tag to my fork:

https://github.com/shiftkey/dugite-native/actions/runs/5446431880/jobs/9907349797#step:6:36

```
🔴 Artifacts folder has 32 assets, expecting 20. Please check the GH Actions artifacts to see which are missing.
```

This is because we have new platforms included, but the count is out of sync. 

The second commit resolves a linter warning where you need to check for `NaN` in the right way:

![](https://github.com/desktop/dugite-native/assets/359239/9311f646-5d5f-4a34-a2ff-49c933322713)

The third commit is a `permissions` addition because actions on forks [do not have permissions to write `content` by default when in restricted mode](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).

Working release links:

 - https://github.com/shiftkey/dugite-native/actions/runs/5446940214
 - https://github.com/shiftkey/dugite-native/releases/tag/v2.39.3-shiftkey5