### PR TITLE
CI: rework patches to lower GLIBC requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       matrix:
         os: [macos-11, windows-2019, ubuntu-20.04]
         arch: [x86, x64]
-        go: [1.16.3]
         include:
           - os: macos-11
             friendlyName: macOS
@@ -36,7 +35,6 @@ jobs:
             friendlyName: macOS
             targetPlatform: macOS
             arch: arm64
-            go: 1.16.3
           - os: windows-2019
             friendlyName: Windows
             targetPlatform: win32
@@ -69,10 +67,9 @@ jobs:
           submodules: recursive
           # Needed for script/package.sh to work
           fetch-depth: 0
-      - name: Use go ${{ matrix.go }}
+      - name: Install go
+        if: matrix.targetPlatform == 'macOS'
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
       - name: Install dependencies
         run: npm install
       - name: Check formatting
@@ -108,6 +105,70 @@ jobs:
           sudo dpkg --add-architecture armhf
           sudo apt-get update
           sudo apt-get install gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libcurl4-gnutls-dev:armhf zlib1g-dev:armhf gettext
+      - name: Add patches to minimize needed GLIBC version
+        if: matrix.targetPlatform == 'ubuntu'
+        run: |
+          CURRENT_DIR="$(pwd)"
+          sudo apt-get -yq install python3
+          # download chromium reversion_glibc.py script from chromium source tree at pinned commit (incase they ever move or change it)
+          wget https://raw.githubusercontent.com/chromium/chromium/01bc42d648c45439e1beef8fd25fde3aef9079bc/build/linux/sysroot_scripts/reversion_glibc.py -O /tmp/reversion_glibc.py
+          # set targeted minimum GLIBC to 2.17
+          sed -i 's/26]/17]/g' /tmp/reversion_glibc.py
+          chmod +x /tmp/reversion_glibc.py
+          # download the host libc6 package from apt and patch the binaries in it
+          # replacing the host libc6 at runtime causes crashs and hangs but apt is able to do it without issue
+          sudo apt-get install --download-only --reinstall -y libc6
+          sudo rm -rf /tmp/libc6
+          sudo mkdir /tmp/libc6
+          sudo cp /var/cache/apt/archives/libc6_2.31-*_amd64.deb /tmp/libc6
+          cd /tmp/libc6
+          deb_name="$(ls)"
+          sudo ar x "$deb_name"
+          sudo tar xf data.tar.xz
+          sudo mkdir DEBIAN
+          sudo tar xf control.tar.xz -C DEBIAN
+          sudo rm -f control.tar.xz \
+            data.tar.xz \
+            debian-binary \
+            DEBIAN/md5sums \
+            DEBIAN/archives \
+            DEBIAN/conffiles \
+            "$deb_name"
+
+          # patch libc6 in host download deb and cross compilers using the reversion_glibc.py script
+          files=(/tmp/libc6/lib/x86_64-linux-gnu/libc.so.6 /tmp/libc6/lib/x86_64-linux-gnu/libm.so.6 \
+          /usr/aarch64-linux-gnu/lib/libc.so.6 /usr/aarch64-linux-gnu/lib/libm.so.6 \
+          /usr/arm-linux-gnueabihf/lib/libc.so.6 /usr/arm-linux-gnueabihf/lib/libm.so.6 \
+          /libx32/libc.so.6 /libx32/libm.so.6 \
+          /lib32/libc.so.6 /lib32/libm.so.6 \
+          /usr/i686-linux-gnu/lib/libc.so.6 /usr/i686-linux-gnu/lib/libm.so.6)
+          for file in "${files[@]}"; do
+            [ -f $file ] && sudo python3 /tmp/reversion_glibc.py "$file"
+          done
+
+          # install patched libc6 deb
+          sudo dpkg-deb -b . "$deb_name"
+          sudo apt install --reinstall --allow-downgrades -y ./"$deb_name"
+          cd "$CURRENT_DIR"
+          # __GLIBC_MINOR__ is used as a feature test macro.  Replace it with the
+          # earliest supported version of glibc 2.17
+          files=(/usr/include/features.h \
+          /usr/aarch64-linux-gnu/include/features.h \
+          /usr/arm-linux-gnueabihf/include/features.h \
+          /usr/i686-linux-gnu/include/features.h)
+          for file in "${files[@]}"; do
+            [ -f $file ] && sudo sed -i 's|\(#define\s\+__GLIBC_MINOR__\)|\1 17 //|' "$file"
+          done
+
+          # fcntl64() was introduced in glibc 2.28.  Make sure to use fcntl() instead.
+          files=(/usr/include/fcntl.h \
+          /usr/aarch64-linux-gnu/include/fcntl.h \
+          /usr/arm-linux-gnueabihf/include/fcntl.h \
+          /usr/i686-linux-gnu/include/fcntl.h)
+          for file in "${files[@]}"; do
+            [ -f $file ] && sudo sed -i '{N; s/#ifndef __USE_FILE_OFFSET64\(\nextern int fcntl\)/#if 1\1/}' "$file"
+          done
+          true
       - name: Build (except macOS arm64)
         if: matrix.targetPlatform != 'macOS' || matrix.arch != 'arm64'
         shell: bash

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -22,11 +22,6 @@ fi
 
 case "$TARGET_ARCH" in
   "x64")
-    # __GLIBC_MINOR__ is used as a feature test macro.  Replace it with the
-    # earliest supported version of glibc 2.17 as was previously the case when building on ubuntu-18.04
-    sudo sed -i 's|\(#define\s\+__GLIBC_MINOR__\)|\1 17 //|' "/usr/include/features.h"
-    # fcntl64() was introduced in glibc 2.28.  Make sure to use fcntl() instead.
-    sudo  sed -i '{N; s/#ifndef __USE_FILE_OFFSET64\(\nextern int fcntl\)/#if 1\1/}' "/usr/include/fcntl.h"
     DEPENDENCY_ARCH="amd64"
     export CC="gcc"
     STRIP="strip"
@@ -39,11 +34,6 @@ case "$TARGET_ARCH" in
     HOST="--host=i686-linux-gnu"
     TARGET="--target=i686-linux-gnu" ;;
   "arm64")
-    # __GLIBC_MINOR__ is used as a feature test macro.  Replace it with the
-    # earliest supported version of glibc 2.17 as was previously the case when building on ubuntu-18.04
-    sudo sed -i 's|\(#define\s\+__GLIBC_MINOR__\)|\1 17 //|' "/usr/aarch64-linux-gnu/include/features.h"
-    # fcntl64() was introduced in glibc 2.28.  Make sure to use fcntl() instead.
-    sudo  sed -i '{N; s/#ifndef __USE_FILE_OFFSET64\(\nextern int fcntl\)/#if 1\1/}' "/usr/aarch64-linux-gnu/include/fcntl.h"
     DEPENDENCY_ARCH="arm64"
     export CC="aarch64-linux-gnu-gcc"
     STRIP="aarch64-linux-gnu-strip"


### PR DESCRIPTION
This patch is based on my changes I have made in various other github projects to produce a more stable and inclusive GLIBC lowering method that better matches what chromium developers are doing.

This now includes 32bit architectures (armhf and x86) lowering as well.

https://github.com/theofficialgman/dugite-native/actions/runs/5448912175