### PR TITLE
Add a custom "system level" gitconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0
       - name: Install go
         if: matrix.targetPlatform == 'macOS'
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
       - name: Install dependencies
         run: npm install
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
         run: |
           sudo apt-get install shellcheck
@@ -82,7 +82,7 @@ jobs:
           # Delete the command line tools to make sure they don't get our builds
           # messed up with macOS SDK 11 stuff.
           sudo rm -rf /Library/Developer/CommandLineTools
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           # Needed for script/package.sh to work
@@ -146,7 +146,7 @@ jobs:
           TARGET_PLATFORM: ${{ matrix.targetPlatform }}
           TARGET_ARCH: ${{ matrix.arch }}
       - name: Upload output artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name:
             dugite-native-${{ matrix.targetPlatform }}-${{ matrix.arch }}-output
@@ -161,10 +161,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: './artifacts'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           TARGET_PLATFORM: ${{ matrix.targetPlatform }}
           TARGET_ARCH: ${{ matrix.arch }}
       - name: Upload output artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name:
             dugite-native-${{ matrix.targetPlatform }}-${{ matrix.arch }}-output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           # Delete the command line tools to make sure they don't get our builds
           # messed up with macOS SDK 11 stuff.
           sudo rm -rf /Library/Developer/CommandLineTools
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           # Needed for script/package.sh to work

--- a/resources/posix.gitconfig
+++ b/resources/posix.gitconfig
@@ -1,0 +1,13 @@
+# This is dugite's own custom system-wide gitconfig file for macOS and Linux.
+# On Windows we ship a contained Git environment (minGit) where we can control
+# the system-level configuration but on macOS and Linux /etc/gitconfig is used
+# as the system-wide configuration file and we're unable to modify it.
+#
+# So in order to be able to provide our own sane defaults that can be overriden
+# by the user's global and local configuration we'll tell Git that this file
+# is the system level config (and import the actual system level config)
+[include]
+  path=/etc/gitconfig
+
+[credential "https://dev.azure.com"]
+  useHttpPath = true

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -110,4 +110,8 @@ echo "-- Removing unsupported features"
 rm "$DESTINATION/libexec/git-core/git-svn"
 rm "$DESTINATION/libexec/git-core/git-p4"
 
+echo "-- Copying dugite custom system gitconfig"
+mkdir "$DESTINATION/etc"
+cp "$CURRENT_DIR/../resources/gitconfig" "$DESTINATION/etc/gitconfig"
+
 set +eu

--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -112,6 +112,6 @@ rm "$DESTINATION/libexec/git-core/git-p4"
 
 echo "-- Copying dugite custom system gitconfig"
 mkdir "$DESTINATION/etc"
-cp "$CURRENT_DIR/../resources/gitconfig" "$DESTINATION/etc/gitconfig"
+cp "$CURRENT_DIR/../resources/posix.gitconfig" "$DESTINATION/etc/gitconfig"
 
 set +eu

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -146,6 +146,10 @@ echo "-- Removing unsupported features"
 rm "$DESTINATION/libexec/git-core/git-svn"
 rm "$DESTINATION/libexec/git-core/git-p4"
 
+echo "-- Copying dugite custom system gitconfig"
+mkdir "$DESTINATION/etc"
+cp "$CURRENT_DIR/../resources/gitconfig" "$DESTINATION/etc/gitconfig"
+
 set +eu
 
 echo "-- Static linking research"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -148,7 +148,7 @@ rm "$DESTINATION/libexec/git-core/git-p4"
 
 echo "-- Copying dugite custom system gitconfig"
 mkdir "$DESTINATION/etc"
-cp "$CURRENT_DIR/../resources/gitconfig" "$DESTINATION/etc/gitconfig"
+cp "$CURRENT_DIR/../resources/posix.gitconfig" "$DESTINATION/etc/gitconfig"
 
 set +eu
 

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -94,6 +94,7 @@ git config --file "$SYSTEM_CONFIG" core.symlinks "false"
 git config --file "$SYSTEM_CONFIG" core.autocrlf "true"
 git config --file "$SYSTEM_CONFIG" core.fscache "true"
 git config --file "$SYSTEM_CONFIG" http.sslBackend "schannel"
+git config --file "$SYSTEM_CONFIG" credential.https://dev.azure.com.useHttpPath "true"
 
 # See https://github.com/desktop/desktop/issues/4817#issuecomment-393241303
 # Even though it's not set openssl will auto-discover the one we ship because


### PR DESCRIPTION
Git for Windows ships a whole environment including its own /etc/gitconfig which we can (and do) manipulate during build in order to insert our "sane defaults" into it. On macOS and Linux that's not the case so in this PR we're creating our own system level config that dugite can then instruct Git to use.