### PR TITLE
Bundle GCM under bin

### DIFF
--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -111,11 +111,11 @@ if [[ "$GCM_VERSION" && "$GCM_URL" ]]; then
   COMPUTED_SHA256=$(compute_checksum $GCM_FILE)
   if [ "$COMPUTED_SHA256" = "$GCM_CHECKSUM" ]; then
     echo "GCM: checksums match"
-    SUBFOLDER="$DESTINATION/libexec/git-core"
+    SUBFOLDER="$DESTINATION/bin"
     tar -xvkf $GCM_FILE -C "$SUBFOLDER"
 
     if [[ ! -f "$SUBFOLDER/git-credential-manager" ]]; then
-      echo "After extracting GCM the file was not found under libexec/git-core/"
+      echo "After extracting GCM the file was not found under bin/"
       echo "aborting..."
       exit 1
     fi

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -132,11 +132,11 @@ if [[ "$GCM_VERSION" && "$GCM_URL" ]]; then
   COMPUTED_SHA256=$(compute_checksum $GCM_FILE)
   if [ "$COMPUTED_SHA256" = "$GCM_CHECKSUM" ]; then
     echo "GCM: checksums match"
-    SUBFOLDER="$DESTINATION/libexec/git-core"
+    SUBFOLDER="$DESTINATION/bin"
     tar -xvkf $GCM_FILE -C "$SUBFOLDER"
 
     if [[ ! -f "$SUBFOLDER/git-credential-manager" ]]; then
-      echo "After extracting GCM the file was not found under libexec/git-core/"
+      echo "After extracting GCM the file was not found under bin/"
       echo "aborting..."
       exit 1
     fi


### PR DESCRIPTION
After talking with @dscho I now know that we shouldn't be sticking arbitrary stuff into `libexec/git-core`, that's reserved for... ya know... git-core.

So I've moved the git credential manager into the bin/ folder as per Johannes suggestion. We still drop Git LFS into `libexec/git-core` and I guess we should stop doing that as well but we've had LFS in there forever so let's start with just GCM and tackle LFS in a follow-up PR.