### PR TITLE
Bump artifact-related actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
   build:
     name: ${{ matrix.friendlyName }} ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.image }}
     strategy:
       fail-fast: false
       matrix:
@@ -42,17 +41,14 @@ jobs:
           - os: ubuntu-20.04
             friendlyName: Linux
             targetPlatform: ubuntu
-            image: ubuntu:18.04
           - os: ubuntu-20.04
             friendlyName: Linux
             targetPlatform: ubuntu
             arch: arm64
-            image: ubuntu:18.04
           - os: ubuntu-20.04
             friendlyName: Linux
             targetPlatform: ubuntu
             arch: arm
-            image: ubuntu:18.04
         exclude:
           - os: macos-11
             arch: x86

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, windows-2019, ubuntu-20.04]
+        os: [macos-14, windows-2019, ubuntu-20.04]
         arch: [x86, x64]
         include:
-          - os: macos-11
+          - os: macos-14
             friendlyName: macOS
             targetPlatform: macOS
-          - os: macos-11
+          - os: macos-14
             friendlyName: macOS
             targetPlatform: macOS
             arch: arm64
@@ -50,7 +50,7 @@ jobs:
             targetPlatform: ubuntu
             arch: arm
         exclude:
-          - os: macos-11
+          - os: macos-14
             arch: x86
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, windows-2019, ubuntu-20.04]
+        os: [macos-12, windows-2019, ubuntu-20.04]
         arch: [x86, x64]
         include:
-          - os: macos-14
+          - os: macos-12
             friendlyName: macOS
             targetPlatform: macOS
-          - os: macos-14
+          - os: macos-12
             friendlyName: macOS
             targetPlatform: macOS
             arch: arm64
@@ -50,7 +50,7 @@ jobs:
             targetPlatform: ubuntu
             arch: arm
         exclude:
-          - os: macos-14
+          - os: macos-12
             arch: x86
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
         run: |
           # ubuntu dockerfile is very minimal (only 122 packages are installed)
           # add dependencies expected by scripts
-          apt update
-          apt install -y software-properties-common lsb-release sudo wget curl build-essential jq autoconf automake pkg-config ca-certificates
+          sudo apt update
+          sudo apt install -y software-properties-common lsb-release sudo wget curl build-essential jq autoconf automake pkg-config ca-certificates
           # install new enough git to run actions/checkout
           sudo add-apt-repository ppa:git-core/ppa -y
           sudo apt update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           TARGET_PLATFORM: ${{ matrix.targetPlatform }}
           TARGET_ARCH: ${{ matrix.arch }}
       - name: Upload output artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name:
             dugite-native-${{ matrix.targetPlatform }}-${{ matrix.arch }}-output
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: './artifacts'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,11 @@ jobs:
           sudo apt-get install -y nodejs
           # avoid "fatal: detected dubious ownership in repository at '/__w/dugite-native/dugite-native'" error
           git config --global --add safe.directory '*'
-      # We need to use Xcode 11.7 for maximum compatibility with older macOS (x64)
-      - name: Switch to Xcode 11.7
+      # We need to use Xcode 13.1 for maximum compatibility with older macOS (x64)
+      - name: Switch to Xcode 13.1
         if: matrix.targetPlatform == 'macOS' && matrix.arch == 'x64'
         run: |
-          sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer/
+          sudo xcode-select -s /Applications/Xcode_13.1.app/Contents/Developer/
           # Delete the command line tools to make sure they don't get our builds
           # messed up with macOS SDK 11 stuff.
           sudo rm -rf /Library/Developer/CommandLineTools


### PR DESCRIPTION
- Upgrade `upload-artifacts` and `download-artifacts` to v4
- In order to do that, bump the GLIBC requirements by using Ubuntu 20.04 to build Dugite
- I noticed `macos-11` runners are not available anymore, so I bumped those to `macos-12` and we will use Xcode 13.1 from now on (it's the oldest one available, for maximum compatibility).