### PR TITLE
Add arm64 support for Git for Windows and update to 2.47.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,25 +26,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-12, windows-2019, ubuntu-20.04]
-        arch: [x86, x64]
+        arch: [x86, x64, arm64]
         include:
           - os: macos-12
             friendlyName: macOS
             targetPlatform: macOS
-          - os: macos-12
-            friendlyName: macOS
-            targetPlatform: macOS
-            arch: arm64
           - os: windows-2019
             friendlyName: Windows
             targetPlatform: win32
           - os: ubuntu-20.04
             friendlyName: Linux
             targetPlatform: ubuntu
-          - os: ubuntu-20.04
-            friendlyName: Linux
-            targetPlatform: ubuntu
-            arch: arm64
           - os: ubuntu-20.04
             friendlyName: Linux
             targetPlatform: ubuntu
@@ -121,15 +113,7 @@ jobs:
           sudo dpkg --add-architecture armhf
           sudo apt-get update
           sudo apt-get install -y gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libcurl4-gnutls-dev:armhf zlib1g-dev:armhf libssl-dev:armhf gettext
-      - name: Build (except macOS arm64)
-        if: matrix.targetPlatform != 'macOS' || matrix.arch != 'arm64'
-        shell: bash
-        run: script/build.sh
-        env:
-          TARGET_PLATFORM: ${{ matrix.targetPlatform }}
-          TARGET_ARCH: ${{ matrix.arch }}
-      - name: Build (macOS arm64)
-        if: matrix.targetPlatform == 'macOS' && matrix.arch == 'arm64'
+      - name: Build
         shell: bash
         run: script/build.sh
         env:

--- a/dependencies.json
+++ b/dependencies.json
@@ -65,6 +65,12 @@
         "checksum": "aaca788e04f91676e58654d5ecf96cf03c76768a63b3a6918281a9678884c20c"
       },
       {
+        "platform": "windows",
+        "arch": "arm64",
+        "name": "git-lfs-windows-arm64-v3.6.1.zip",
+        "checksum": "ad40ab00a73ef4bf63c969472d0e5a824686b495dbc01ea8e9e4cc456c49a4b0"
+      },
+      {
         "platform": "darwin",
         "arch": "amd64",
         "name": "git-lfs-darwin-amd64-v3.6.1.zip",

--- a/dependencies.json
+++ b/dependencies.json
@@ -26,43 +26,49 @@
     ]
   },
   "git-lfs": {
-    "version": "v3.5.1",
+    "version": "v3.6.0",
     "files": [
       {
         "platform": "linux",
         "arch": "amd64",
-        "name": "git-lfs-linux-amd64-v3.5.1.tar.gz",
-        "checksum": "6f28eb19faa7a968882dca190d92adc82493378b933958d67ceaeb9ebe4d731e"
+        "name": "git-lfs-linux-amd64-v3.6.0.tar.gz",
+        "checksum": "fff4746159aa7a7b42ef1aa30fed03b534df48a7dbe116d65296c0f0c43c594d"
       },
       {
         "platform": "linux",
         "arch": "x86",
-        "name": "git-lfs-linux-386-v3.5.1.tar.gz",
-        "checksum": "4436bbc404427b2ca24108582cb1945dd806851d8634d287b8f37fb211718bee"
+        "name": "git-lfs-linux-386-v3.6.0.tar.gz",
+        "checksum": "10da3c2ec46aa76287653a8d8576c271701d1fa899432f5bc3ace2a33c2116f0"
       },
       {
         "platform": "linux",
         "arch": "arm64",
-        "name": "git-lfs-linux-arm64-v3.5.1.tar.gz",
-        "checksum": "4f8700aacaa0fd26ae5300fb0996aed14d1fd0ce1a63eb690629c132ff5163a9"
+        "name": "git-lfs-linux-arm64-v3.6.0.tar.gz",
+        "checksum": "9509504b3b825054c3d07af5edc1cc9c00732c6f0fd4a060f04bfbf0f1279fca"
       },
       {
         "platform": "linux",
         "arch": "arm",
-        "name": "git-lfs-linux-arm-v3.5.1.tar.gz",
-        "checksum": "03923d8badf5c382920390414ad7084c5d87b246b180474d09961e3831f552e2"
+        "name": "git-lfs-linux-arm-v3.6.0.tar.gz",
+        "checksum": "bc7190755703017d193bee182a4edbf610d6df6d006d6fdd6ad411d552468456"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "name": "git-lfs-windows-386-v3.5.1.zip",
-        "checksum": "ea5138789c4f19ed71d30c3e407f43bd270771028d37e5292378a8ea2c154377"
+        "name": "git-lfs-windows-386-v3.6.0.zip",
+        "checksum": "58b3029f60d51b8775a0cbb21a39b8504967577a8bb4b3feabb1f1a48bf7fb33"
       },
       {
         "platform": "windows",
         "arch": "amd64",
-        "name": "git-lfs-windows-amd64-v3.5.1.zip",
-        "checksum": "94435072f6b3a6f9064b277760c8340e432b5ede0db8205d369468b9be52c6b6"
+        "name": "git-lfs-windows-amd64-v3.6.0.zip",
+        "checksum": "62fce4cfd453493966c387db167ba1aa46ecee730ae24a5b902a1d05650fb4ce"
+      },
+      {
+        "platform": "windows",
+        "arch": "arm64",
+        "name": "git-lfs-windows-arm64-v3.6.0.zip",
+        "checksum": "6e8d6051760bd90372ed7dfcace02f80dddec374bab61b9525e263722f97de7b"
       }
     ]
   },

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,20 +1,27 @@
 {
   "git": {
-    "version": "v2.45.3",
+    "version": "v2.47.1",
     "packages": [
       {
         "platform": "windows",
         "arch": "amd64",
-        "filename": "MinGit-2.45.2.2-64-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.45.2.windows.2/MinGit-2.45.2.2-64-bit.zip",
-        "checksum": "93ce6daa762cd82b7558162b7caee6fc60dc6e630b0b4b1a15307e7480a0c64d"
+        "filename": "MinGit-2.47.1.2-64-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/MinGit-2.47.1.2-64-bit.zip",
+        "checksum": "5bafb35dfb249b89d726b37824eeb5022379f0e51f5fbf9c29f49bef57e85b42"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "filename": "MinGit-2.45.2.2-32-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.45.2.windows.2/MinGit-2.45.2.2-32-bit.zip",
-        "checksum": "f1b3272a303435c89e60645e2f1460b9c6679032f6ff15b21713b7d44044dd3e"
+        "filename": "MinGit-2.47.1.2-32-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/MinGit-2.47.1.2-32-bit.zip",
+        "checksum": "adae5363e224be913af65b3b8c454463e220dd12c811bf5f298952ba4106589a"
+      },
+      {
+        "platform": "windows",
+        "arch": "arm64",
+        "filename": "MinGit-2.47.1.2-arm64.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/MinGit-2.47.1.2-arm64.zip",
+        "checksum": "c74dd8e25b2337bbef059440966ba7bf96da4b4a8bc9bf9c759a2bc5a868da2b"
       }
     ]
   },

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,20 +1,27 @@
 {
   "git": {
-    "version": "v2.45.1",
+    "version": "v2.47.1",
     "packages": [
       {
         "platform": "windows",
         "arch": "amd64",
-        "filename": "MinGit-2.45.1-64-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.45.1.windows.1/MinGit-2.45.1-64-bit.zip",
-        "checksum": "f7ba0e2acdc603cf8893b446f6871c869b7644b88a1116b00d6b30fb30f18c74"
+        "filename": "MinGit-2.47.1-64-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip",
+        "checksum": "50b04b55425b5c465d076cdb184f63a0cd0f86f6ec8bb4d5860114a713d2c29a"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "filename": "MinGit-2.45.1-32-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.45.1.windows.1/MinGit-2.45.1-32-bit.zip",
-        "checksum": "9c1089f13f5873190ac9473375126ba697df6773188f01ca2d6a0cf920c44287"
+        "filename": "MinGit-2.47.1-32-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-32-bit.zip",
+        "checksum": "3c0fa6e3096c2304f8c6af9cb6bb35623b2e615771cf7be45f9632af83bd9864"
+      },
+      {
+        "platform": "windows",
+        "arch": "arm64",
+        "filename": "MinGit-2.47.1-arm64.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-arm64.zip",
+        "checksum": "fc5747e187a70147404a94da104dc9f6005a3d45a78a56dbfa132075ad4a45e4"
       }
     ]
   },

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -10,13 +10,24 @@ if [[ -z "${DESTINATION}" ]]; then
   exit 1
 fi
 
-if [ "$TARGET_ARCH" = "x64" ]; then
-  DEPENDENCY_ARCH="amd64"
-  MINGW_DIR="mingw64"
-else
-  DEPENDENCY_ARCH="x86"
-  MINGW_DIR="mingw32"
-fi
+case $TARGET_ARCH in
+  x64)
+    DEPENDENCY_ARCH="amd64"
+    MINGW_DIR="mingw64"
+    ;;
+  x86)
+    DEPENDENCY_ARCH="x86"
+    MINGW_DIR="mingw32"
+    ;;
+  arm64)
+    DEPENDENCY_ARCH="arm64"
+    MINGW_DIR="clangarm64"
+    ;;
+  *)
+	  echo "Unsupported architecture: $TARGET_ARCH"
+    exit 1
+	  ;;
+esac
 
 GIT_LFS_VERSION=$(jq --raw-output ".[\"git-lfs\"].version[1:]" dependencies.json)
 GIT_LFS_CHECKSUM="$(jq --raw-output ".\"git-lfs\".files[] | select(.arch == \"$DEPENDENCY_ARCH\" and .platform == \"windows\") | .checksum" dependencies.json)"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -24,9 +24,9 @@ case $TARGET_ARCH in
     MINGW_DIR="clangarm64"
     ;;
   *)
-	  echo "Unsupported architecture: $TARGET_ARCH"
+    echo "Unsupported architecture: $TARGET_ARCH"
     exit 1
-	  ;;
+    ;;
 esac
 
 GIT_LFS_VERSION=$(jq --raw-output ".[\"git-lfs\"].version[1:]" dependencies.json)

--- a/script/update-git-lfs.ts
+++ b/script/update-git-lfs.ts
@@ -93,6 +93,7 @@ async function run(): Promise<boolean> {
     `git-lfs-linux-arm-${version}.tar.gz`,
     `git-lfs-windows-386-${version}.zip`,
     `git-lfs-windows-amd64-${version}.zip`,
+    `git-lfs-windows-arm64-${version}.zip`,
   ]
 
   const newFiles = []

--- a/script/update-git.ts
+++ b/script/update-git.ts
@@ -74,9 +74,13 @@ async function getLatestStableRelease() {
 async function getPackageDetails(
   assets: ReleaseAssets,
   body: string,
-  arch: string
+  arch: 'amd64' | 'x86' | 'arm64'
 ) {
-  const archValue = arch === 'amd64' ? '64-bit' : '32-bit'
+  const archValue = {
+    amd64: '64-bit',
+    x86: '32-bit',
+    arm64: 'arm64',
+  }[arch]
 
   const minGitFile = assets.find(
     a => a.name.indexOf('MinGit') !== -1 && a.name.indexOf(archValue) !== -1
@@ -181,12 +185,17 @@ async function run() {
 
   const package64bit = await getPackageDetails(assets, body, 'amd64')
   const package32bit = await getPackageDetails(assets, body, 'x86')
+  const packagearm64 = await getPackageDetails(assets, body, 'arm64')
 
-  if (package64bit == null || package32bit == null) {
+  if (package64bit == null || package32bit == null || packagearm64 == null) {
     return
   }
 
-  updateGitDependencies(latestGitVersion, [package64bit, package32bit])
+  updateGitDependencies(latestGitVersion, [
+    package64bit,
+    package32bit,
+    packagearm64,
+  ])
 
   console.log(
     `✅ Updated dependencies metadata to Git ${latestGitVersion} (Git for Windows ${version})`


### PR DESCRIPTION
Git for Windows added support for arm64 releases in their 2.47.1 version. Let's add support for it in the `update-git.ts` script.

I also ran the `update-git.ts` script after adding this change, which correctly added the arm64 version of Git to `dependencies.json`. I'll leave it up to you if you also want to include that commit already, or if you want to address the version bump separately.

Ref: https://github.com/git-for-windows/git/releases/tag/v2.47.1.windows.1
Ref: https://github.com/git-for-windows/git/issues/3107#issuecomment-2498275856