### PR TITLE
Don't need go any more

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,6 @@ jobs:
           submodules: recursive
           # Needed for script/package.sh to work
           fetch-depth: 0
-      - name: Install go
-        if: matrix.targetPlatform == 'macOS'
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22.x'
       - name: Install dependencies
         run: npm install
       - name: Check formatting


### PR DESCRIPTION
As of https://github.com/desktop/dugite-native/commit/4981d67487f4ccbedcd1301d3a682e7f76160faf we're bundling the precompiled Git LFS binaries on macOS so we don't need go any more.