### PR TITLE
Only package the bits from LFS that we really need

### DIFF
--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -36,6 +36,8 @@ GIT_LFS_FILENAME="$(jq --raw-output ".\"git-lfs\".files[] | select(.arch == \"$D
 
 # shellcheck source=script/compute-checksum.sh
 source "$CURRENT_DIR/compute-checksum.sh"
+# shellcheck source=script/verify-lfs-contents.sh
+source "$CURRENT_DIR/verify-lfs-contents.sh"
 
 echo "-- Building git at $SOURCE to $DESTINATION"
 
@@ -84,6 +86,9 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/libexec/git-core"
+
+    verify_lfs_contents "$GIT_LFS_FILE"
+
     unzip -j $GIT_LFS_FILE -d "$SUBFOLDER" "*/git-lfs"
 
     if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -100,7 +100,6 @@ DESTDIR="$DESTINATION" \
   make strip install
 )
 
-set -o xtrace
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.tar.gz
@@ -129,7 +128,6 @@ if [[ "$GIT_LFS_VERSION" ]]; then
 else
   echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi
-set +o xtrace
 
 if [[ "$GCM_VERSION" && "$GCM_URL" ]]; then
   echo "-- Bundling GCM"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -63,6 +63,8 @@ GCM_URL="$(jq --raw-output ".\"git-credential-manager\".files[] | select(.arch =
 source "$CURRENT_DIR/compute-checksum.sh"
 # shellcheck source=script/check-static-linking.sh
 source "$CURRENT_DIR/check-static-linking.sh"
+# shellcheck source=script/verify-lfs-contents.sh
+source "$CURRENT_DIR/verify-lfs-contents.sh"
 
 echo " -- Building vanilla curl at $CURL_INSTALL_DIR instead of distro-specific version"
 
@@ -108,7 +110,9 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/libexec/git-core"
-    tar -xvf $GIT_LFS_FILE -C "$SUBFOLDER" --strip-components=1 --exclude='*.sh' --exclude="*.md"
+
+    verify_lfs_contents "$GIT_LFS_FILE"
+    tar -zxvf "$GIT_LFS_FILE" --strip-components=1 -C "$SUBFOLDER" "*/git-lfs"
 
     if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
       echo "After extracting Git LFS the file was not found under libexec/git-core/"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -114,7 +114,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
 
     verify_lfs_contents "$GIT_LFS_FILE"
 
-    tar -zxvf "$GIT_LFS_FILE" --strip-components=1 -C "$SUBFOLDER" "*/git-lfs"
+    tar -zxvf "$GIT_LFS_FILE" --strip-components=1 -C "$SUBFOLDER" --wildcards "*/git-lfs"
 
     if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
       echo "After extracting Git LFS the file was not found under libexec/git-core/"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -100,6 +100,7 @@ DESTDIR="$DESTINATION" \
   make strip install
 )
 
+set -o xtrace
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.tar.gz
@@ -112,6 +113,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
     SUBFOLDER="$DESTINATION/libexec/git-core"
 
     verify_lfs_contents "$GIT_LFS_FILE"
+
     tar -zxvf "$GIT_LFS_FILE" --strip-components=1 -C "$SUBFOLDER" "*/git-lfs"
 
     if [[ ! -f "$SUBFOLDER/git-lfs" ]]; then
@@ -127,6 +129,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
 else
   echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
 fi
+set +o xtrace
 
 if [[ "$GCM_VERSION" && "$GCM_URL" ]]; then
   echo "-- Bundling GCM"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -60,7 +60,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
 
     verify_lfs_contents "$GIT_LFS_FILE"
 
-    unzip -j $GIT_LFS_FILE -x '*.md' -d "$SUBFOLDER"
+    unzip -j $GIT_LFS_FILE -d "$SUBFOLDER" "*/git-lfs.exe"
 
     if [[ ! -f "$SUBFOLDER/git-lfs.exe" ]]; then
       echo "After extracting Git LFS the file was not found under /mingw64/libexec/git-core/"

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -27,6 +27,8 @@ GIT_FOR_WINDOWS_CHECKSUM=$(jq --raw-output ".git.packages[] | select(.arch == \"
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=script/compute-checksum.sh
 source "$CURRENT_DIR/compute-checksum.sh"
+# shellcheck source=script/verify-lfs-contents.sh
+source "$CURRENT_DIR/verify-lfs-contents.sh"
 
 mkdir -p "$DESTINATION"
 
@@ -55,6 +57,9 @@ if [[ "$GIT_LFS_VERSION" ]]; then
   if [ "$COMPUTED_SHA256" = "$GIT_LFS_CHECKSUM" ]; then
     echo "Git LFS: checksums match"
     SUBFOLDER="$DESTINATION/$MINGW_DIR/libexec/git-core"
+
+    verify_lfs_contents "$GIT_LFS_FILE"
+
     unzip -j $GIT_LFS_FILE -x '*.md' -d "$SUBFOLDER"
 
     if [[ ! -f "$SUBFOLDER/git-lfs.exe" ]]; then

--- a/script/verify-lfs-contents.sh
+++ b/script/verify-lfs-contents.sh
@@ -27,5 +27,5 @@ verify_lfs_contents() {
   grep -qvE "^(CHANGELOG\.md|README\.md|git-lfs(\.exe)?|install\.sh|man)$" <<< "$TOPLEVEL" && {
     echo "Git LFS: unexpected files in the LFS archive, aborting..."
     exit 1
-  }
+  } || true
 }

--- a/script/verify-lfs-contents.sh
+++ b/script/verify-lfs-contents.sh
@@ -17,14 +17,14 @@ verify_lfs_contents() {
     echo "Git LFS: found no contents in LFS archive, aborting..."
     exit 1
   }
+
+  TOPLEVEL=$(echo "$CONTENTS" | cut -d/ -f2 | sort | uniq | grep .)
   
   # Sanity check to make sure we react if git-lfs starts adding more stuff to
   # their release packages. Note that this only looks that the top
   # (technically second) level folder so new stuff in the man folder won't
   # get caught here.
-  (echo "$CONTENTS" | cut -d/ -f2 | sort | uniq | grep -vE "^(CHANGELOG\.md|README\.md|git-lfs(\.exe)?|install\.sh|man)$")
-
-  [[ 0 -eq $? ]] && {
+  grep -qvE "^(CHANGELOG\.md|README\.md|git-lfs(\.exe)?|install\.sh|man)$" <<< "$TOPLEVEL" && {
     echo "Git LFS: unexpected files in the LFS archive, aborting..."
     exit 1
   }

--- a/script/verify-lfs-contents.sh
+++ b/script/verify-lfs-contents.sh
@@ -1,0 +1,10 @@
+verify_lfs_contents() {
+  # Sanity check to make sure we react if git-lfs starts adding more stuff to
+  # their release packages. Note that this only looks that the top
+  # (technically second) level folder so new stuff in the man folder won't
+  # get caught here.
+  test -z "`unzip -qql $1 | cut -d / -f 2 | sort | uniq | grep -vE "^(CHANGELOG\.md|README\.md|git-lfs(\.exe)?|install\.sh|man)$"`" || {
+    echo "Git LFS: unexpected files in the zip, aborting..."
+    exit 1
+  }
+}

--- a/script/verify-lfs-contents.sh
+++ b/script/verify-lfs-contents.sh
@@ -1,10 +1,29 @@
 verify_lfs_contents() {
+
+  CONTENTS=""
+
+  if [[ "$1" == *.zip ]]; then
+    CONTENTS="$(unzip -qql $1)"
+  elif [[ "$1" == *.tar.gz ]]; then
+    CONTENTS="$(tar -tzf "$1")"
+  else
+    echo "Unknown file type for $1"
+    exit 1
+  fi
+
+  test -z "$CONTENTS" && {
+    echo "Git LFS: found no contents in LFS archive, aborting..."
+    exit 1
+  }
+  
+  UNKNOWN=$(echo "$CONTENTS" | cut -d/ -f2 | sort | uniq | grep -vE "^(CHANGELOG\.md|README\.md|git-lfs(\.exe)?|install\.sh|man)$")
+
   # Sanity check to make sure we react if git-lfs starts adding more stuff to
   # their release packages. Note that this only looks that the top
   # (technically second) level folder so new stuff in the man folder won't
   # get caught here.
-  test -z "`unzip -qql $1 | cut -d / -f 2 | sort | uniq | grep -vE "^(CHANGELOG\.md|README\.md|git-lfs(\.exe)?|install\.sh|man)$"`" || {
-    echo "Git LFS: unexpected files in the zip, aborting..."
+  test -z "$UNKNOWN" || {
+    echo "Git LFS: unexpected files in the LFS archive, aborting..."
     exit 1
   }
 }

--- a/script/verify-lfs-contents.sh
+++ b/script/verify-lfs-contents.sh
@@ -18,13 +18,13 @@ verify_lfs_contents() {
     exit 1
   }
   
-  UNKNOWN=$(echo "$CONTENTS" | cut -d/ -f2 | sort | uniq | grep -vE "^(CHANGELOG\.md|README\.md|git-lfs(\.exe)?|install\.sh|man)$")
-
   # Sanity check to make sure we react if git-lfs starts adding more stuff to
   # their release packages. Note that this only looks that the top
   # (technically second) level folder so new stuff in the man folder won't
   # get caught here.
-  test -z "$UNKNOWN" || {
+  (echo "$CONTENTS" | cut -d/ -f2 | sort | uniq | grep -vE "^(CHANGELOG\.md|README\.md|git-lfs(\.exe)?|install\.sh|man)$")
+
+  [[ 0 -eq $? ]] && {
     echo "Git LFS: unexpected files in the LFS archive, aborting..."
     exit 1
   }

--- a/script/verify-lfs-contents.sh
+++ b/script/verify-lfs-contents.sh
@@ -24,6 +24,7 @@ verify_lfs_contents() {
   # their release packages. Note that this only looks that the top
   # (technically second) level folder so new stuff in the man folder won't
   # get caught here.
+  # shellcheck disable=SC2015
   grep -qvE "^(CHANGELOG\.md|README\.md|git-lfs(\.exe)?|install\.sh|man)$" <<< "$TOPLEVEL" && {
     echo "Git LFS: unexpected files in the LFS archive, aborting..."
     exit 1

--- a/script/verify-lfs-contents.sh
+++ b/script/verify-lfs-contents.sh
@@ -1,11 +1,13 @@
+#!/bin/bash -e
+
 verify_lfs_contents() {
 
   CONTENTS=""
 
   if [[ "$1" == *.zip ]]; then
-    CONTENTS="$(unzip -qql $1)"
+    CONTENTS=$(unzip -qql "$1")
   elif [[ "$1" == *.tar.gz ]]; then
-    CONTENTS="$(tar -tzf "$1")"
+    CONTENTS=$(tar -tzf "$1")
   else
     echo "Unknown file type for $1"
     exit 1


### PR DESCRIPTION
We found out that we were shipping the man pages for LFS into the libexec folder. No need for that, let's just get rid of everything that's not the LFS executable.