### PR TITLE
Bump Git to 2.49.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-2019, ubuntu-20.04]
+        os: [macos-13, windows-2019, ubuntu-24.04]
         arch: [x86, x64, arm64]
         include:
           - os: macos-13
@@ -34,10 +34,10 @@ jobs:
           - os: windows-2019
             friendlyName: Windows
             targetPlatform: win32
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             friendlyName: Linux
             targetPlatform: ubuntu
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             friendlyName: Linux
             targetPlatform: ubuntu
             arch: arm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-2019, ubuntu-24.04]
+        os: [macos-13, windows-2019, ubuntu-22.04]
         arch: [x86, x64, arm64]
         include:
           - os: macos-13
@@ -34,10 +34,10 @@ jobs:
           - os: windows-2019
             friendlyName: Windows
             targetPlatform: win32
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             friendlyName: Linux
             targetPlatform: ubuntu
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             friendlyName: Linux
             targetPlatform: ubuntu
             arch: arm

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,27 +1,27 @@
 {
   "git": {
-    "version": "v2.47.1",
+    "version": "v2.49.0",
     "packages": [
       {
         "platform": "windows",
         "arch": "amd64",
-        "filename": "MinGit-2.47.1.2-64-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/MinGit-2.47.1.2-64-bit.zip",
-        "checksum": "5bafb35dfb249b89d726b37824eeb5022379f0e51f5fbf9c29f49bef57e85b42"
+        "filename": "MinGit-2.49.0-64-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-64-bit.zip",
+        "checksum": "971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5"
       },
       {
         "platform": "windows",
         "arch": "x86",
-        "filename": "MinGit-2.47.1.2-32-bit.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/MinGit-2.47.1.2-32-bit.zip",
-        "checksum": "adae5363e224be913af65b3b8c454463e220dd12c811bf5f298952ba4106589a"
+        "filename": "MinGit-2.49.0-32-bit.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-32-bit.zip",
+        "checksum": "6d6439436d537624f619ffbf5dba49bcdc4ee1219c5c2756277669928fba2b74"
       },
       {
         "platform": "windows",
         "arch": "arm64",
-        "filename": "MinGit-2.47.1.2-arm64.zip",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/MinGit-2.47.1.2-arm64.zip",
-        "checksum": "c74dd8e25b2337bbef059440966ba7bf96da4b4a8bc9bf9c759a2bc5a868da2b"
+        "filename": "MinGit-2.49.0-arm64.zip",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/MinGit-2.49.0-arm64.zip",
+        "checksum": "847bbe519443cd24c716f490a769056a35f42474cafb757663e1dceca159e911"
       }
     ]
   },

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -81,7 +81,7 @@ DESTDIR="$DESTINATION" \
   make strip install
 )
 
-objdump "$DESTINATION/libexec/git-core/git-remote-http"
+objdump -p "$DESTINATION/libexec/git-core/git-remote-http"
 
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -81,8 +81,6 @@ DESTDIR="$DESTINATION" \
   make strip install
 )
 
-objdump -p "$DESTINATION/libexec/git-core/git-remote-http"
-
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.tar.gz

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -81,6 +81,8 @@ DESTDIR="$DESTINATION" \
   make strip install
 )
 
+objdump "$DESTINATION/libexec/git-core/git-remote-http"
+
 if [[ "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.tar.gz

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -66,20 +66,6 @@ source "$CURRENT_DIR/check-static-linking.sh"
 # shellcheck source=script/verify-lfs-contents.sh
 source "$CURRENT_DIR/verify-lfs-contents.sh"
 
-echo " -- Building vanilla curl at $CURL_INSTALL_DIR instead of distro-specific version"
-
-CURL_FILE_NAME="curl-7.61.1"
-CURL_FILE="$CURL_FILE_NAME.tar.gz"
-
-cd /tmp || exit 1
-curl -LO "https://curl.haxx.se/download/$CURL_FILE"
-tar -xf $CURL_FILE
-
-(
-cd $CURL_FILE_NAME || exit 1
-./configure --prefix="$CURL_INSTALL_DIR" "$HOST" "$TARGET"
-make install
-)
 echo " -- Building git at $SOURCE to $DESTINATION"
 
 (
@@ -89,7 +75,6 @@ make configure
 CFLAGS='-Wall -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -U_FORTIFY_SOURCE' \
   LDFLAGS='-Wl,-Bsymbolic-functions -Wl,-z,relro' ac_cv_iconv_omits_bom=no ac_cv_fread_reads_directories=no ac_cv_snprintf_returns_bogus=no \
   ./configure $HOST \
-  --with-curl="$CURL_INSTALL_DIR" \
   --prefix=/
 sed -i "s/STRIP = strip/STRIP = $STRIP/" Makefile
 DESTDIR="$DESTINATION" \

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -25,22 +25,22 @@ case "$TARGET_ARCH" in
     DEPENDENCY_ARCH="amd64"
     export CC="gcc"
     STRIP="strip"
-    HOST=""
+    HOST="" ;;
   "x86")
     DEPENDENCY_ARCH="x86"
     export CC="i686-linux-gnu-gcc"
     STRIP="i686-gnu-strip"
-    HOST="--host=i686-linux-gnu"
+    HOST="--host=i686-linux-gnu" ;;
   "arm64")
     DEPENDENCY_ARCH="arm64"
     export CC="aarch64-linux-gnu-gcc"
     STRIP="aarch64-linux-gnu-strip"
-    HOST="--host=aarch64-linux-gnu"
+    HOST="--host=aarch64-linux-gnu" ;;
   "arm")
     DEPENDENCY_ARCH="arm"
     export CC="arm-linux-gnueabihf-gcc"
     STRIP="arm-linux-gnueabihf-strip"
-    HOST="--host=arm-linux-gnueabihf"
+    HOST="--host=arm-linux-gnueabihf" ;;
   *)
     exit 1 ;;
 esac

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -26,25 +26,21 @@ case "$TARGET_ARCH" in
     export CC="gcc"
     STRIP="strip"
     HOST=""
-    TARGET="" ;;
   "x86")
     DEPENDENCY_ARCH="x86"
     export CC="i686-linux-gnu-gcc"
     STRIP="i686-gnu-strip"
     HOST="--host=i686-linux-gnu"
-    TARGET="--target=i686-linux-gnu" ;;
   "arm64")
     DEPENDENCY_ARCH="arm64"
     export CC="aarch64-linux-gnu-gcc"
     STRIP="aarch64-linux-gnu-strip"
     HOST="--host=aarch64-linux-gnu"
-    TARGET="--target=aarch64-linux-gnu" ;;
   "arm")
     DEPENDENCY_ARCH="arm"
     export CC="arm-linux-gnueabihf-gcc"
     STRIP="arm-linux-gnueabihf-strip"
     HOST="--host=arm-linux-gnueabihf"
-    TARGET="--target=arm-linux-gnueabihf" ;;
   *)
     exit 1 ;;
 esac


### PR DESCRIPTION
2.49.0 is the latest version of Git but I spoke with `@dscho` and it seems there are no bugs of concern so let's go for it.