### PR TITLE
NO_GIT_LFS=1 skips bundling Git LFS

### DIFF
--- a/script/build-macos.sh
+++ b/script/build-macos.sh
@@ -76,7 +76,7 @@ echo "-- Building git at $SOURCE to $DESTINATION"
     MACOSX_DEPLOYMENT_TARGET=$MACOSX_BUILD_VERSION
 )
 
-if [[ "$GIT_LFS_VERSION" ]]; then
+if [[ "${NO_GIT_LFS:-}" != "1" && "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.tar.gz
   GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/${GIT_LFS_FILENAME}"
@@ -102,7 +102,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
     exit 1
   fi
 else
-  echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+  echo "-- Skipped bundling Git LFS"
 fi
 
 GCM_VERSION="$(jq --raw-output '.["git-credential-manager"].version[1:]' dependencies.json)"

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -81,7 +81,7 @@ DESTDIR="$DESTINATION" \
   make strip install
 )
 
-if [[ "$GIT_LFS_VERSION" ]]; then
+if [[ "${NO_GIT_LFS:-}" != "1" && "$GIT_LFS_VERSION" ]]; then
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.tar.gz
   GIT_LFS_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/${GIT_LFS_FILENAME}"
@@ -107,7 +107,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
     exit 1
   fi
 else
-  echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+  echo "-- Skipped bundling Git LFS"
 fi
 
 if [[ "$GCM_VERSION" && "$GCM_URL" ]]; then

--- a/script/build-win32.sh
+++ b/script/build-win32.sh
@@ -57,7 +57,7 @@ else
 fi
 
 
-if [[ "$GIT_LFS_VERSION" ]]; then
+if [[ "${NO_GIT_LFS:-}" != "1" && "$GIT_LFS_VERSION" ]]; then
   # download Git LFS, verify its the right contents, and unpack it
   echo "-- Bundling Git LFS"
   GIT_LFS_FILE=git-lfs.zip
@@ -84,7 +84,7 @@ if [[ "$GIT_LFS_VERSION" ]]; then
     exit 1
   fi
 else
-  echo "-- Skipped bundling Git LFS (set GIT_LFS_VERSION to include it in the bundle)"
+  echo "-- Skipped bundling Git LFS"
 fi
 
 if [[ -f "$DESTINATION/etc/gitconfig" ]]; then


### PR DESCRIPTION
[This PR](https://github.com/desktop/dugite-native/pull/123) made bundling Git LFS dependent on GIT_LFS_VERSION being set. If not set, it would be skipped.

Over the years this has changed to reading the value from a file: 
```bash
GIT_LFS_VERSION="$(jq --raw-output '.["git-lfs"].version[1:]' dependencies.json)"
```

Which is fair enough, but there's no longer a way to easily disable bundling in CI. You'll need to edit `dependencies.json` manually or use a hacky script to change the json.

This PR allows skipping the bundle by setting NO_GIT_LFS=1.
