### PR TITLE
Replace third-party actions with gh CLI for releases and PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,12 +94,12 @@ jobs:
           git tag ${{ github.event.inputs.version }}
           git push origin ${{ github.event.inputs['dry-run'] == 'true' && '--dry-run ' || ''  }}${{ github.event.inputs.version }}
       - name: Release
-        uses: softprops/action-gh-release@v2
         if: ${{ github.event.inputs['dry-run'] != 'true' }}
-        with:
-          body_path: ${{ github.workspace }}/script/release_notes.txt
-          tag_name: ${{ github.event.inputs.version }}
-          draft: ${{ github.event.inputs.draft }}
-          prerelease: ${{ github.event.inputs.prerelease }}
-          files: ${{ github.workspace }}/artifacts/dugite-*
-          fail_on_unmatched_files: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.event.inputs.version }} \
+            --notes-file ${{ github.workspace }}/script/release_notes.txt \
+            ${{ github.event.inputs.draft == 'true' && '--draft' || '' }} \
+            ${{ github.event.inputs.prerelease == 'true' && '--prerelease' || '' }} \
+            ${{ github.workspace }}/artifacts/dugite-*

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -87,6 +87,10 @@ jobs:
           branch="update-dependencies-auto-${{ github.run_id }}"
           git checkout -b "$branch"
           git add -A
+          if git diff --cached --quiet; then
+            echo "No dependency changes detected; skipping commit, push, and pull request creation."
+            exit 0
+          fi
           git commit -m "${{ steps.pr-contents.outputs.title }}"
           git push origin "$branch"
           gh pr create \

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -83,6 +83,7 @@ jobs:
             ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
           GIT_COMMITTER_NAME: dugite-releases[bot]
           GIT_COMMITTER_EMAIL: 241944550+dugite-releases[bot]@users.noreply.github.com
+          PR_TITLE: ${{ steps.pr-contents.outputs.title }}
         run: |
           branch="update-dependencies-auto-${{ github.run_id }}"
           git checkout -b "$branch"
@@ -91,9 +92,9 @@ jobs:
             echo "No dependency changes detected; skipping commit, push, and pull request creation."
             exit 0
           fi
-          git commit -m "${{ steps.pr-contents.outputs.title }}"
+          git commit -m "$PR_TITLE"
           git push origin "$branch"
           gh pr create \
-            --title "${{ steps.pr-contents.outputs.title }}" \
+            --title "$PR_TITLE" \
             --body-file ./pr-body.md \
             --head "$branch"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -29,7 +29,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ vars.RELEASES_APP_ID }}
+          private-key: ${{ secrets.RELEASES_APP_KEY }}
       - uses: actions/checkout@v5
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -70,11 +77,6 @@ jobs:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
             github.run_id }}
         run: node ./script/generate-release-pr-contents.mjs >> $GITHUB_OUTPUT
-      - uses: actions/create-github-app-token@v1
-        id: generate-token
-        with:
-          app-id: ${{ vars.RELEASES_APP_ID }}
-          private-key: ${{ secrets.RELEASES_APP_KEY }}
       - name: Create pull request
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -76,12 +76,20 @@ jobs:
           app-id: ${{ vars.RELEASES_APP_ID }}
           private-key: ${{ secrets.RELEASES_APP_KEY }}
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          branch: update-dependencies-auto-${{ github.run_id }}
-          delete-branch: true
-          commit-message: ${{ steps.pr-contents.outputs.title }}
-          title: ${{ steps.pr-contents.outputs.title }}
-          body-path: ./pr-body.md
-          draft: false
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GIT_AUTHOR_NAME: ${{ steps.get_author.outputs.name || github.actor }}
+          GIT_AUTHOR_EMAIL:
+            ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+          GIT_COMMITTER_NAME: dugite-releases[bot]
+          GIT_COMMITTER_EMAIL: 241944550+dugite-releases[bot]@users.noreply.github.com
+        run: |
+          branch="update-dependencies-auto-${{ github.run_id }}"
+          git checkout -b "$branch"
+          git add -A
+          git commit -m "${{ steps.pr-contents.outputs.title }}"
+          git push origin "$branch"
+          gh pr create \
+            --title "${{ steps.pr-contents.outputs.title }}" \
+            --body-file ./pr-body.md \
+            --head "$branch"


### PR DESCRIPTION
Replace `softprops/action-gh-release` and `peter-evans/create-pull-request` actions with direct `gh` CLI commands.

## Changes

- **release.yml**: Use `gh release create` instead of `softprops/action-gh-release@v2`
- **update-dependencies.yml**: Use `git` + `gh pr create` instead of `peter-evans/create-pull-request@v7`

This reduces our dependency on third-party actions for core workflow operations.