### PR TITLE
Link Linux git against libcurl (openssl) instead of libcurl-gnutls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,13 @@ jobs:
         if: matrix.targetPlatform == 'ubuntu' && matrix.arch == 'x64'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-gnutls-dev libexpat1-dev zlib1g-dev gettext libssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libexpat1-dev zlib1g-dev gettext libssl-dev
       - name: Install extra dependencies for building Git on Ubuntu (x86)
         if: matrix.targetPlatform == 'ubuntu' && matrix.arch == 'x86'
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install -y gcc-i686-linux-gnu binutils-i686-gnu libcurl4-gnutls-dev:i386 zlib1g-dev:i386 libssl-dev:i386 gettext
+          sudo apt-get install -y gcc-i686-linux-gnu binutils-i686-gnu libcurl4-openssl-dev:i386 zlib1g-dev:i386 libssl-dev:i386 gettext
       - name: Install extra dependencies for building Git on Ubuntu (arm64)
         if: matrix.targetPlatform == 'ubuntu' && matrix.arch == 'arm64'
         run: |
@@ -112,7 +112,7 @@ jobs:
           echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ $(lsb_release -s -c)-updates main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
           sudo dpkg --add-architecture arm64
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libcurl4-gnutls-dev:arm64 zlib1g-dev:arm64 libssl-dev:arm64 gettext
+          sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libcurl4-openssl-dev:arm64 zlib1g-dev:arm64 libssl-dev:arm64 gettext
       - name: Install extra dependencies for building Git on Ubuntu (arm)
         if: matrix.targetPlatform == 'ubuntu' && matrix.arch == 'arm'
         run: |
@@ -121,7 +121,7 @@ jobs:
           echo "deb [arch=arm64,armhf] http://azure.ports.ubuntu.com/ $(lsb_release -s -c)-updates main universe multiverse restricted" | sudo tee -a /etc/apt/sources.list
           sudo dpkg --add-architecture armhf
           sudo apt-get update
-          sudo apt-get install -y gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libcurl4-gnutls-dev:armhf zlib1g-dev:armhf libssl-dev:armhf gettext
+          sudo apt-get install -y gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libcurl4-openssl-dev:armhf zlib1g-dev:armhf libssl-dev:armhf gettext
       - name: Build
         shell: bash
         run: script/build.sh

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -15,11 +15,6 @@ if [[ -z "${DESTINATION}" ]]; then
   exit 1
 fi
 
-if [[ -z "${CURL_INSTALL_DIR}" ]]; then
-  echo "Required environment variable CURL_INSTALL_DIR was not set"
-  exit 1
-fi
-
 case "$TARGET_ARCH" in
   "x64")
     DEPENDENCY_ARCH="amd64"

--- a/script/build.sh
+++ b/script/build.sh
@@ -22,5 +22,4 @@ ROOT=$(dirname "$CURRENT_DIR")
 BASEDIR=$ROOT \
   SOURCE="$ROOT/git" \
   DESTINATION="/tmp/build/git" \
-  CURL_INSTALL_DIR="/tmp/build/curl" \
   bash "$SCRIPT"


### PR DESCRIPTION
## Why

The Linux builds link `libexec/git-core/git-remote-https` against `libcurl-gnutls.so.4`, a SONAME that only exists on Debian/Ubuntu. On Fedora/RHEL/CentOS only `libcurl.so.4` is available, so any HTTPS clone/fetch fails with:

```
git-remote-https: error while loading shared libraries: libcurl-gnutls.so.4: cannot open shared object file: No such file or directory
```

This is a regression. It was originally fixed in #102 (which built curl from source against OpenSSL and pointed git at it via `--with-curl`). Commit c64f13f (from #524, "Bump Git to 2.49.0") dropped that from-source curl build and the `--with-curl` flag, so the build fell back to Ubuntu's distro curl. Because CI installs `libcurl4-gnutls-dev`, git's `-lcurl` resolves to the gnutls variant and the resulting binary ends up needing `libcurl-gnutls.so.4`.

## What

Instead of reintroducing the from-source curl build, this switches the build dependency to `libcurl4-openssl-dev` across all four arches (x64, x86, arm64, arm). That makes git link against the standard `libcurl.so.4` SONAME, which is present on all mainstream distros including Fedora/RHEL/CentOS. The two curl variants share the same libcurl ABI; Debian only splits the SONAME so both TLS backends can co-install, so targeting `libcurl.so.4` is safe.

Also removes the now-unused `CURL_INSTALL_DIR` plumbing that #524 left behind in `script/build-ubuntu.sh` and `script/build.sh`.

## Verifying

The existing x64 CI job already runs a real HTTPS clone plus `check_static_linking`. After this change, `objdump -T` on `git-remote-https` should report `libcurl.so.4` (not `libcurl-gnutls.so.4`) and the clone should succeed.

Fixes #527